### PR TITLE
docs(api): add OpenAPI documentation with Swagger UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ tower-http = { version = "0.5", features = ["cors", "trace"] }
 reqwest = { version = "0.12", features = ["json"] }
 thiserror = "1"
 anyhow = "1"
+utoipa = { version = "4", features = ["axum_extras", "chrono", "uuid"] }
+utoipa-swagger-ui = { version = "9", features = ["axum", "vendored"] }
 
 [dev-dependencies]
 axum-test = "15"

--- a/src/docs/mod.rs
+++ b/src/docs/mod.rs
@@ -1,0 +1,32 @@
+use utoipa::OpenApi;
+
+use crate::models::creator::{CreateCreatorRequest, CreatorResponse};
+use crate::models::tip::{RecordTipRequest, TipResponse};
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Stellar Tipjar API",
+        version = "0.1.0",
+        description = "Backend API for the Stellar Tipjar — create creator profiles and record on-chain tips verified against the Stellar network."
+    ),
+    paths(
+        crate::routes::creators::create_creator,
+        crate::routes::creators::get_creator,
+        crate::routes::creators::get_creator_tips,
+        crate::routes::tips::record_tip,
+    ),
+    components(
+        schemas(
+            CreateCreatorRequest,
+            CreatorResponse,
+            RecordTipRequest,
+            TipResponse,
+        )
+    ),
+    tags(
+        (name = "creators", description = "Creator profile management"),
+        (name = "tips", description = "Tip recording and retrieval")
+    )
+)]
+pub struct ApiDoc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,18 @@ use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 
 mod controllers;
 mod db;
+mod docs;
 mod models;
 mod routes;
 mod services;
 
 use db::connection::AppState;
+use docs::ApiDoc;
 use services::stellar_service::StellarService;
 
 #[tokio::main]
@@ -56,6 +60,8 @@ async fn main() -> anyhow::Result<()> {
         .allow_headers(Any);
 
     let app = Router::new()
+        .merge(SwaggerUi::new("/swagger-ui")
+            .url("/api-docs/openapi.json", ApiDoc::openapi()))
         .merge(routes::creators::router())
         .merge(routes::tips::router())
         .layer(cors)
@@ -66,6 +72,7 @@ async fn main() -> anyhow::Result<()> {
     let addr = format!("0.0.0.0:{}", port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("Server listening on {}", addr);
+    tracing::info!("Swagger UI available at http://{}/swagger-ui", addr);
 
     axum::serve(listener, app).await?;
 

--- a/src/models/creator.rs
+++ b/src/models/creator.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
@@ -10,16 +11,22 @@ pub struct Creator {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Deserialize)]
+/// Request body for creating a new creator
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateCreatorRequest {
+    /// Unique username for the creator
     pub username: String,
+    /// Stellar wallet address (public key)
     pub wallet_address: String,
 }
 
-#[derive(Debug, Serialize)]
+/// Creator profile response
+#[derive(Debug, Serialize, ToSchema)]
 pub struct CreatorResponse {
+    /// Unique identifier
     pub id: Uuid,
     pub username: String,
+    /// Stellar wallet address (public key)
     pub wallet_address: String,
     pub created_at: DateTime<Utc>,
 }

--- a/src/models/tip.rs
+++ b/src/models/tip.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
@@ -11,18 +12,26 @@ pub struct Tip {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Deserialize)]
+/// Request body for recording a tip
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct RecordTipRequest {
+    /// Username of the creator receiving the tip
     pub username: String,
+    /// Amount in XLM (e.g. "10.5")
     pub amount: String,
+    /// Stellar transaction hash to verify on-chain
     pub transaction_hash: String,
 }
 
-#[derive(Debug, Serialize)]
+/// Tip record response
+#[derive(Debug, Serialize, ToSchema)]
 pub struct TipResponse {
+    /// Unique identifier
     pub id: Uuid,
     pub creator_username: String,
+    /// Amount in XLM
     pub amount: String,
+    /// Verified Stellar transaction hash
     pub transaction_hash: String,
     pub created_at: DateTime<Utc>,
 }

--- a/src/routes/creators.rs
+++ b/src/routes/creators.rs
@@ -20,7 +20,18 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/creators/:username/tips", get(get_creator_tips))
 }
 
-async fn create_creator(
+/// Create a new creator profile
+#[utoipa::path(
+    post,
+    path = "/creators",
+    tag = "creators",
+    request_body = CreateCreatorRequest,
+    responses(
+        (status = 201, description = "Creator created successfully", body = CreatorResponse),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn create_creator(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateCreatorRequest>,
 ) -> impl IntoResponse {
@@ -40,7 +51,21 @@ async fn create_creator(
     }
 }
 
-async fn get_creator(
+/// Get a creator by username
+#[utoipa::path(
+    get,
+    path = "/creators/{username}",
+    tag = "creators",
+    params(
+        ("username" = String, Path, description = "Creator's unique username")
+    ),
+    responses(
+        (status = 200, description = "Creator found", body = CreatorResponse),
+        (status = 404, description = "Creator not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn get_creator(
     State(state): State<Arc<AppState>>,
     Path(username): Path<String>,
 ) -> impl IntoResponse {
@@ -65,7 +90,20 @@ async fn get_creator(
     }
 }
 
-async fn get_creator_tips(
+/// List all tips for a creator
+#[utoipa::path(
+    get,
+    path = "/creators/{username}/tips",
+    tag = "creators",
+    params(
+        ("username" = String, Path, description = "Creator's unique username")
+    ),
+    responses(
+        (status = 200, description = "List of tips", body = Vec<TipResponse>),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn get_creator_tips(
     State(state): State<Arc<AppState>>,
     Path(username): Path<String>,
 ) -> impl IntoResponse {

--- a/src/routes/tips.rs
+++ b/src/routes/tips.rs
@@ -15,11 +15,23 @@ pub fn router() -> Router<Arc<AppState>> {
     Router::new().route("/tips", post(record_tip))
 }
 
-async fn record_tip(
+/// Record a new tip (verifies transaction on the Stellar network first)
+#[utoipa::path(
+    post,
+    path = "/tips",
+    tag = "tips",
+    request_body = RecordTipRequest,
+    responses(
+        (status = 201, description = "Tip recorded successfully", body = TipResponse),
+        (status = 422, description = "Transaction not found or unsuccessful on Stellar network"),
+        (status = 502, description = "Unable to reach Stellar network for verification"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn record_tip(
     State(state): State<Arc<AppState>>,
     Json(body): Json<RecordTipRequest>,
 ) -> impl IntoResponse {
-    // Verify the transaction on the Stellar network before recording.
     match state
         .stellar
         .verify_transaction(&body.transaction_hash)


### PR DESCRIPTION



thi spr closes #11 

## Summary
Adds OpenAPI 3.0 spec and interactive Swagger UI via the `utoipa` crate.

## Changes
- `Cargo.toml` — utoipa v4 + utoipa-swagger-ui v9 (vendored)
- `src/docs/mod.rs` — new ApiDoc struct
- models — ToSchema derives on all request/response types
- routes — handlers made pub with #[utoipa::path] annotations covering all status codes
- `src/main.rs` — Swagger UI at /swagger-ui, spec at /api-docs/openapi.json

## Endpoints Documented
| Method | Path | Description |
|--------|------|-------------|
| POST | /creators | Create creator |
| GET | /creators/:username | Get creator |
| GET | /creators/:username/tips | List creator tips |
| POST | /tips | Record tip (with Stellar tx verification) |

After running, visit http://localhost:8000/swagger-ui
