### PR TITLE
Add Stellar transaction retry logic with exponential backoff

### DIFF
--- a/src/services/circuit_breaker.rs
+++ b/src/services/circuit_breaker.rs
@@ -1,0 +1,128 @@
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Circuit breaker states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircuitState {
+    /// Normal operation; requests are allowed.
+    Closed,
+    /// Too many failures; requests are rejected immediately.
+    Open,
+    /// Cooling off; a single probe request is allowed to test recovery.
+    HalfOpen,
+}
+
+/// A thread-safe circuit breaker that trips after consecutive failures
+/// and recovers after a cooldown period.
+pub struct CircuitBreaker {
+    /// Number of consecutive failures before tripping open.
+    failure_threshold: u32,
+    /// How long the circuit stays open before transitioning to half-open.
+    recovery_timeout: Duration,
+    /// Current consecutive failure count.
+    failure_count: AtomicU32,
+    /// Unix timestamp (seconds) when the circuit was last tripped open.
+    last_failure_time: AtomicU64,
+}
+
+impl CircuitBreaker {
+    pub fn new(failure_threshold: u32, recovery_timeout: Duration) -> Self {
+        Self {
+            failure_threshold,
+            recovery_timeout,
+            failure_count: AtomicU32::new(0),
+            last_failure_time: AtomicU64::new(0),
+        }
+    }
+
+    /// Return the current circuit state.
+    pub fn state(&self) -> CircuitState {
+        let failures = self.failure_count.load(Ordering::SeqCst);
+        if failures < self.failure_threshold {
+            return CircuitState::Closed;
+        }
+
+        let last_fail = self.last_failure_time.load(Ordering::SeqCst);
+        let now = now_secs();
+
+        if now - last_fail >= self.recovery_timeout.as_secs() {
+            CircuitState::HalfOpen
+        } else {
+            CircuitState::Open
+        }
+    }
+
+    /// Check whether a request should be allowed through.
+    pub fn allow_request(&self) -> bool {
+        match self.state() {
+            CircuitState::Closed => true,
+            CircuitState::HalfOpen => true, // allow probe request
+            CircuitState::Open => false,
+        }
+    }
+
+    /// Record a successful operation. Resets the failure counter.
+    pub fn record_success(&self) {
+        self.failure_count.store(0, Ordering::SeqCst);
+    }
+
+    /// Record a failed operation. Increments the failure counter and
+    /// updates the last failure timestamp.
+    pub fn record_failure(&self) {
+        self.failure_count.fetch_add(1, Ordering::SeqCst);
+        self.last_failure_time.store(now_secs(), Ordering::SeqCst);
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_starts_closed() {
+        let cb = CircuitBreaker::new(3, Duration::from_secs(30));
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.allow_request());
+    }
+
+    #[test]
+    fn test_opens_after_threshold() {
+        let cb = CircuitBreaker::new(3, Duration::from_secs(30));
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Closed);
+
+        cb.record_failure(); // hits threshold
+        assert_eq!(cb.state(), CircuitState::Open);
+        assert!(!cb.allow_request());
+    }
+
+    #[test]
+    fn test_resets_on_success() {
+        let cb = CircuitBreaker::new(3, Duration::from_secs(30));
+        cb.record_failure();
+        cb.record_failure();
+        cb.record_success();
+
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.allow_request());
+    }
+
+    #[test]
+    fn test_half_open_after_timeout() {
+        let cb = CircuitBreaker::new(2, Duration::from_secs(0)); // 0 sec timeout for test
+        cb.record_failure();
+        cb.record_failure();
+
+        // Recovery timeout is 0 seconds, so it should immediately be half-open
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+        assert!(cb.allow_request());
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,2 +1,4 @@
+pub mod circuit_breaker;
+pub mod retry;
 pub mod stellar_service;
 pub mod tip_service;

--- a/src/services/retry.rs
+++ b/src/services/retry.rs
@@ -1,0 +1,140 @@
+use std::future::Future;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Configuration for retry with exponential backoff.
+#[derive(Clone, Debug)]
+pub struct RetryConfig {
+    /// Maximum number of retry attempts (excluding the initial call).
+    pub max_retries: u32,
+    /// Base delay between retries. Actual delay = base * 2^attempt.
+    pub base_delay: Duration,
+    /// Maximum delay cap to prevent excessively long waits.
+    pub max_delay: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            base_delay: Duration::from_millis(500),
+            max_delay: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Execute an async operation with exponential backoff retry.
+///
+/// Retries on `Err` results up to `config.max_retries` times.
+/// The delay between retries doubles each attempt, capped at `max_delay`.
+pub async fn with_retry<F, Fut, T, E>(config: &RetryConfig, operation: F) -> Result<T, E>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    let mut last_err: Option<E> = None;
+
+    for attempt in 0..=config.max_retries {
+        match operation().await {
+            Ok(value) => {
+                if attempt > 0 {
+                    tracing::info!("Operation succeeded on attempt {}", attempt + 1);
+                }
+                return Ok(value);
+            }
+            Err(err) => {
+                if attempt < config.max_retries {
+                    let delay = config
+                        .base_delay
+                        .saturating_mul(2u32.saturating_pow(attempt))
+                        .min(config.max_delay);
+                    tracing::warn!(
+                        "Attempt {}/{} failed: {}. Retrying in {:?}",
+                        attempt + 1,
+                        config.max_retries + 1,
+                        err,
+                        delay,
+                    );
+                    sleep(delay).await;
+                }
+                last_err = Some(err);
+            }
+        }
+    }
+
+    Err(last_err.expect("at least one attempt was made"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_succeeds_on_first_try() {
+        let config = RetryConfig {
+            max_retries: 3,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(10),
+        };
+
+        let result: Result<&str, String> =
+            with_retry(&config, || async { Ok("ok") }).await;
+        assert_eq!(result.unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn test_succeeds_after_retries() {
+        let config = RetryConfig {
+            max_retries: 3,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(10),
+        };
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let result: Result<&str, String> = with_retry(&config, || {
+            let c = counter_clone.clone();
+            async move {
+                let attempt = c.fetch_add(1, Ordering::SeqCst);
+                if attempt < 2 {
+                    Err("transient error".to_string())
+                } else {
+                    Ok("ok")
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), "ok");
+        assert_eq!(counter.load(Ordering::SeqCst), 3); // 2 failures + 1 success
+    }
+
+    #[tokio::test]
+    async fn test_fails_after_max_retries() {
+        let config = RetryConfig {
+            max_retries: 2,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(10),
+        };
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let result: Result<&str, String> = with_retry(&config, || {
+            let c = counter_clone.clone();
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Err("permanent error".to_string())
+            }
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "permanent error");
+        assert_eq!(counter.load(Ordering::SeqCst), 3); // initial + 2 retries
+    }
+}

--- a/src/services/stellar_service.rs
+++ b/src/services/stellar_service.rs
@@ -1,5 +1,10 @@
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::circuit_breaker::CircuitBreaker;
+use super::retry::{with_retry, RetryConfig};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize)]
@@ -23,6 +28,8 @@ pub struct StellarService {
     #[allow(dead_code)]
     pub rpc_url: String,
     pub network: String,
+    retry_config: RetryConfig,
+    circuit_breaker: Arc<CircuitBreaker>,
 }
 
 impl StellarService {
@@ -31,14 +38,27 @@ impl StellarService {
             client: Client::new(),
             rpc_url,
             network,
+            retry_config: RetryConfig::default(),
+            circuit_breaker: Arc::new(CircuitBreaker::new(5, Duration::from_secs(60))),
         }
     }
 
     /// Verify that a transaction exists and was successful on the Stellar network.
+    ///
+    /// Uses retry with exponential backoff for transient network errors and a
+    /// circuit breaker to avoid hammering a failing Horizon server.
     pub async fn verify_transaction(
         &self,
         transaction_hash: &str,
     ) -> anyhow::Result<bool> {
+        if !self.circuit_breaker.allow_request() {
+            tracing::warn!(
+                "Circuit breaker open; skipping verification for {}",
+                transaction_hash
+            );
+            return Err(anyhow::anyhow!("Stellar service circuit breaker is open"));
+        }
+
         let horizon_base = if self.network == "mainnet" {
             "https://horizon.stellar.org"
         } else {
@@ -46,19 +66,43 @@ impl StellarService {
         };
 
         let url = format!("{}/transactions/{}", horizon_base, transaction_hash);
-        let response = self.client.get(&url).send().await;
+        let client = self.client.clone();
+        let cb = self.circuit_breaker.clone();
 
-        match response {
-            Ok(resp) if resp.status().is_success() => {
-                let tx: HorizonTransactionResponse = resp.json().await?;
-                Ok(tx.successful)
+        let result = with_retry(&self.retry_config, || {
+            let client = client.clone();
+            let url = url.clone();
+            async move {
+                let resp = client
+                    .get(&url)
+                    .send()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("HTTP request failed: {}", e))?;
+
+                if resp.status().is_success() {
+                    let tx: HorizonTransactionResponse = resp
+                        .json()
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+                    Ok(tx.successful)
+                } else if resp.status().as_u16() == 404 {
+                    Ok(false)
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Horizon returned status {}",
+                        resp.status()
+                    ))
+                }
             }
-            Ok(_) => Ok(false),
-            Err(e) => {
-                tracing::warn!("Failed to verify transaction {}: {}", transaction_hash, e);
-                Ok(false)
-            }
+        })
+        .await;
+
+        match &result {
+            Ok(_) => cb.record_success(),
+            Err(_) => cb.record_failure(),
         }
+
+        result
     }
 
     /// Get the current health of the Stellar network connection.


### PR DESCRIPTION
## Description
Implement retry logic for Stellar transaction verification with exponential backoff and circuit breaker pattern.

## Changes
- Add `src/services/retry.rs` with configurable exponential backoff:
  - Default: 3 retries, 500ms base delay, 10s max delay
  - Generic `with_retry()` function usable for any async operation
- Add `src/services/circuit_breaker.rs` with Closed/Open/HalfOpen states:
  - Trips open after 5 consecutive failures
  - Recovers after 60s cooldown (half-open allows probe request)
  - Thread-safe using atomics
- Integrate both into `StellarService::verify_transaction()`
- Add tests for retry (3 tests) and circuit breaker (4 tests)

## How to test
- `cargo test` to run all unit tests
- Set `STELLAR_NETWORK=testnet` and verify retry behavior with invalid tx hashes

Closes #28