### PR TITLE
feat(api): add GraphQL with DataLoader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ hex = "0.4"
 base64 = "0.22"
 utoipa = { version = "4", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
+async-graphql = { version = "7", features = ["uuid", "chrono"] }
+async-graphql-axum = "7"
+tokio-stream = "0.1"
+async-trait = "0.1"
 
 [dev-dependencies]
 axum-test = "15"

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -13,4 +13,5 @@ pub struct AppState {
     pub stellar: StellarService,
     pub performance: Arc<PerformanceMonitor>,
     pub redis: Option<ConnectionManager>,
+    pub broadcast_tx: broadcast::Sender<TipEvent>,
 }

--- a/src/graphql/context.rs
+++ b/src/graphql/context.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+use async_graphql::dataloader::DataLoader;
+use crate::db::connection::AppState;
+use super::dataloaders::{CreatorLoader, TipLoader};
+
+pub struct GraphQLContext {
+    pub state: Arc<AppState>,
+    pub creator_loader: DataLoader<CreatorLoader>,
+    pub tip_loader: DataLoader<TipLoader>,
+}
+
+impl GraphQLContext {
+    pub fn new(state: Arc<AppState>) -> Self {
+        let creator_loader = DataLoader::new(
+            CreatorLoader { pool: state.db.clone() },
+            tokio::spawn,
+        );
+        let tip_loader = DataLoader::new(
+            TipLoader { pool: state.db.clone() },
+            tokio::spawn,
+        );
+        Self { state, creator_loader, tip_loader }
+    }
+}

--- a/src/graphql/dataloaders.rs
+++ b/src/graphql/dataloaders.rs
@@ -1,0 +1,50 @@
+use std::{collections::HashMap, sync::Arc};
+use async_graphql::dataloader::Loader;
+use sqlx::PgPool;
+use crate::models::{creator::Creator, tip::Tip};
+
+pub struct CreatorLoader {
+    pub pool: PgPool,
+}
+
+impl Loader<String> for CreatorLoader {
+    type Value = Creator;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(&self, keys: &[String]) -> Result<HashMap<String, Creator>, Self::Error> {
+        let creators = sqlx::query_as::<_, Creator>(
+            "SELECT id, username, wallet_address, email, created_at FROM creators WHERE username = ANY($1)",
+        )
+        .bind(keys.to_vec())
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Arc::new)?;
+
+        Ok(creators.into_iter().map(|c| (c.username.clone(), c)).collect())
+    }
+}
+
+pub struct TipLoader {
+    pub pool: PgPool,
+}
+
+impl Loader<String> for TipLoader {
+    type Value = Vec<Tip>;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(&self, keys: &[String]) -> Result<HashMap<String, Vec<Tip>>, Self::Error> {
+        let tips = sqlx::query_as::<_, Tip>(
+            "SELECT id, creator_username, amount, transaction_hash, created_at FROM tips WHERE creator_username = ANY($1) ORDER BY created_at DESC",
+        )
+        .bind(keys.to_vec())
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Arc::new)?;
+
+        let mut map: HashMap<String, Vec<Tip>> = HashMap::new();
+        for tip in tips {
+            map.entry(tip.creator_username.clone()).or_default().push(tip);
+        }
+        Ok(map)
+    }
+}

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -1,0 +1,6 @@
+pub mod context;
+pub mod dataloaders;
+pub mod mutations;
+pub mod queries;
+pub mod schema;
+pub mod subscriptions;

--- a/src/graphql/mutations.rs
+++ b/src/graphql/mutations.rs
@@ -1,0 +1,63 @@
+use async_graphql::{Context, InputObject, Object, Result};
+use validator::Validate;
+
+use crate::controllers::creator_controller;
+use crate::models::creator::CreateCreatorRequest;
+use crate::models::tip::RecordTipRequest;
+use crate::services::tip_service::TipService;
+use super::context::GraphQLContext;
+use super::queries::{GqlCreator, GqlTip};
+
+#[derive(InputObject)]
+pub struct CreateCreatorInput {
+    pub username: String,
+    pub wallet_address: String,
+    pub email: Option<String>,
+}
+
+#[derive(InputObject)]
+pub struct RecordTipInput {
+    pub username: String,
+    pub amount: String,
+    pub transaction_hash: String,
+}
+
+pub struct MutationRoot;
+
+#[Object]
+impl MutationRoot {
+    async fn create_creator(&self, ctx: &Context<'_>, input: CreateCreatorInput) -> Result<GqlCreator> {
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let req = CreateCreatorRequest {
+            username: input.username,
+            wallet_address: input.wallet_address,
+            email: input.email,
+        };
+        req.validate().map_err(|e| async_graphql::Error::new(e.to_string()))?;
+        let creator = creator_controller::create_creator(&gql_ctx.state, req)
+            .await
+            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+        Ok(GqlCreator::from(creator))
+    }
+
+    async fn record_tip(&self, ctx: &Context<'_>, input: RecordTipInput) -> Result<GqlTip> {
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+
+        gql_ctx.state.stellar.verify_transaction(&input.transaction_hash)
+            .await
+            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+
+        let req = RecordTipRequest {
+            username: input.username,
+            amount: input.amount,
+            transaction_hash: input.transaction_hash,
+        };
+        req.validate().map_err(|e| async_graphql::Error::new(e.to_string()))?;
+
+        let tip = TipService::new()
+            .record_tip(gql_ctx.state.clone(), req)
+            .await
+            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+        Ok(GqlTip::from(tip))
+    }
+}

--- a/src/graphql/queries.rs
+++ b/src/graphql/queries.rs
@@ -1,0 +1,88 @@
+use async_graphql::{Context, Object, Result, SimpleObject};
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use super::context::GraphQLContext;
+
+#[derive(SimpleObject, Clone)]
+pub struct GqlCreator {
+    pub id: Uuid,
+    pub username: String,
+    pub wallet_address: String,
+    pub email: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<crate::models::creator::Creator> for GqlCreator {
+    fn from(c: crate::models::creator::Creator) -> Self {
+        Self {
+            id: c.id,
+            username: c.username,
+            wallet_address: c.wallet_address,
+            email: c.email,
+            created_at: c.created_at,
+        }
+    }
+}
+
+#[derive(SimpleObject, Clone)]
+pub struct GqlTip {
+    pub id: Uuid,
+    pub creator_username: String,
+    pub amount: String,
+    pub transaction_hash: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<crate::models::tip::Tip> for GqlTip {
+    fn from(t: crate::models::tip::Tip) -> Self {
+        Self {
+            id: t.id,
+            creator_username: t.creator_username,
+            amount: t.amount,
+            transaction_hash: t.transaction_hash,
+            created_at: t.created_at,
+        }
+    }
+}
+
+pub struct QueryRoot;
+
+#[Object]
+impl QueryRoot {
+    /// Look up a single creator by username. Uses DataLoader to batch DB calls.
+    async fn creator(&self, ctx: &Context<'_>, username: String) -> Result<Option<GqlCreator>> {
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let result = gql_ctx.creator_loader.load_one(username).await?;
+        Ok(result.map(GqlCreator::from))
+    }
+
+    /// List all tips for a creator. Uses DataLoader to batch DB calls.
+    async fn tips_for_creator(&self, ctx: &Context<'_>, username: String) -> Result<Vec<GqlTip>> {
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let tips = gql_ctx.tip_loader.load_one(username).await?.unwrap_or_default();
+        Ok(tips.into_iter().map(GqlTip::from).collect())
+    }
+
+    /// List creators with optional pagination.
+    async fn creators(
+        &self,
+        ctx: &Context<'_>,
+        limit: Option<i64>,
+        offset: Option<i64>,
+    ) -> Result<Vec<GqlCreator>> {
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let limit = limit.unwrap_or(20).min(100);
+        let offset = offset.unwrap_or(0);
+
+        let creators = sqlx::query_as::<_, crate::models::creator::Creator>(
+            "SELECT id, username, wallet_address, email, created_at FROM creators ORDER BY created_at DESC LIMIT $1 OFFSET $2",
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&gql_ctx.state.db)
+        .await?;
+
+        Ok(creators.into_iter().map(GqlCreator::from).collect())
+    }
+}

--- a/src/graphql/schema.rs
+++ b/src/graphql/schema.rs
@@ -1,0 +1,32 @@
+use async_graphql::Schema;
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
+use axum::Extension;
+use std::sync::Arc;
+
+use crate::db::connection::AppState;
+use super::context::GraphQLContext;
+use super::mutations::MutationRoot;
+use super::queries::QueryRoot;
+use super::subscriptions::SubscriptionRoot;
+
+pub type AppSchema = Schema<QueryRoot, MutationRoot, SubscriptionRoot>;
+
+pub fn build_schema(state: Arc<AppState>) -> AppSchema {
+    Schema::build(QueryRoot, MutationRoot, SubscriptionRoot)
+        .data(GraphQLContext::new(state))
+        .finish()
+}
+
+pub async fn graphql_handler(
+    Extension(schema): Extension<AppSchema>,
+    req: GraphQLRequest,
+) -> GraphQLResponse {
+    schema.execute(req.into_inner()).await.into()
+}
+
+pub async fn graphql_ws_handler(
+    Extension(schema): Extension<AppSchema>,
+    protocol: GraphQLSubscription,
+) -> impl axum::response::IntoResponse {
+    protocol.on_upgrade(schema)
+}

--- a/src/graphql/subscriptions.rs
+++ b/src/graphql/subscriptions.rs
@@ -1,0 +1,46 @@
+use async_graphql::{Context, Result, SimpleObject, Subscription};
+use async_graphql::futures_util::Stream;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
+
+use super::context::GraphQLContext;
+
+/// A real-time tip notification delivered over GraphQL subscriptions.
+#[derive(SimpleObject, Clone)]
+pub struct TipNotification {
+    pub creator_username: String,
+    pub tipper_id: String,
+    /// Amount in stroops (1 XLM = 10_000_000 stroops).
+    pub amount: i64,
+    pub timestamp: i64,
+}
+
+pub struct SubscriptionRoot;
+
+#[Subscription]
+impl SubscriptionRoot {
+    /// Subscribe to new tips for a specific creator.
+    async fn tip_received(
+        &self,
+        ctx: &Context<'_>,
+        creator_username: String,
+    ) -> Result<impl Stream<Item = TipNotification>> {
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let rx = gql_ctx.state.broadcast_tx.subscribe();
+
+        let stream = BroadcastStream::new(rx).filter_map(move |result| {
+            let username = creator_username.clone();
+            match result {
+                Ok(event) if event.creator_id == username => Some(TipNotification {
+                    creator_username: event.creator_id,
+                    tipper_id: event.tipper_id,
+                    amount: event.amount as i64,
+                    timestamp: event.timestamp,
+                }),
+                _ => None,
+            }
+        });
+
+        Ok(stream)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod docs;
 pub mod email;
 pub mod errors;
+pub mod graphql;
 pub mod middleware;
 pub mod models;
 pub mod routes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod db;
 mod docs;
 mod email;
 mod errors;
+mod graphql;
 mod logging;
 mod middleware;
 mod models;
@@ -27,6 +28,7 @@ mod ws;
 
 use db::connection::AppState;
 use docs::ApiDoc;
+use graphql::schema::{graphql_handler, graphql_ws_handler};
 use services::stellar_service::StellarService;
 use tokio::sync::broadcast;
 
@@ -94,6 +96,7 @@ async fn main() -> anyhow::Result<()> {
         stellar,
         performance,
         redis,
+        broadcast_tx,
     });
 
     let cors = CorsLayer::new()
@@ -149,12 +152,16 @@ async fn main() -> anyhow::Result<()> {
 
     let x_request_id = axum::http::HeaderName::from_static("x-request-id");
 
+    let gql_schema = graphql::schema::build_schema(Arc::clone(&state));
+
     let app = Router::new()
         .route("/ws", axum::routing::get(ws::ws_handler))
+        .route("/graphql", axum::routing::post(graphql_handler).get(graphql_ws_handler))
         .merge(SwaggerUi::new("/swagger-ui")
             .url("/api-docs/openapi.json", ApiDoc::openapi()))
         .merge(v1)
         .merge(v2)
+        .layer(axum::Extension(gql_schema))
         .layer(cors)
         .layer(TraceLayer::new_for_http())
         .layer(axum::middleware::from_fn(middleware::cache::cache_control))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -57,7 +57,7 @@ pub async fn create_test_app(pool: PgPool) -> (Router, String) {
         stellar,
         performance,
         redis,
-        email: email_sender,
+        broadcast_tx: tokio::sync::broadcast::channel(16).0,
     });
 
     (create_app(state), "mock_token".into())


### PR DESCRIPTION
## feat(api): Add GraphQL API with DataLoader Pattern

### What
Adds a GraphQL endpoint alongside the existing REST API.

New endpoint: POST /graphql (queries & mutations), GET /graphql (subscriptions over WebSocket)

### Queries
graphql
creator(username: String!)        # single creator via DataLoader
tipsForCreator(username: String!)  # tips via DataLoader
creators(limit: Int, offset: Int)  # paginated list


### Mutations
graphql
createCreator(input: CreateCreatorInput!)  # validates + inserts
recordTip(input: RecordTipInput!)          # verifies on-chain, then records


### Subscriptions
graphql
tipReceived(creatorUsername: String!)  # real-time tip events


### Why
- **DataLoader** batches all creator/tip lookups into single WHERE x = ANY($1) queries — no N+1
- **Subscriptions** reuse the existing broadcast::Sender<TipEvent> already in AppState, no new infrastructure
- **Mutations** reuse existing controllers and StellarService for on-chain verification — no duplicated logic

### Changes
| File | Change |
|---|---|
| src/graphql/ | New module (context, dataloaders, queries, mutations, subscriptions, schema) |
| src/db/connection.rs | Added broadcast_tx to AppState |
| src/main.rs | Mount /graphql, build schema, pass broadcast_tx into state |
| Cargo.toml | Added async-graphql, async-graphql-axum, tokio-stream |
| tests/common/mod.rs | Fixed AppState construction for tests |


Closes #70 