### PR TITLE
feat(api): add pagination and filtering for endpoints

### DIFF
--- a/src/controllers/tip_controller.rs
+++ b/src/controllers/tip_controller.rs
@@ -8,7 +8,7 @@ use crate::db::transaction;
 use crate::errors::{AppError, AppResult};
 use crate::metrics::collectors::DB_QUERY_DURATION_SECONDS; // Kept from your branch
 use crate::models::pagination::{PaginatedResponse, PaginationParams};
-use crate::models::tip::{RecordTipRequest, Tip};
+use crate::models::tip::{RecordTipRequest, Tip, TipFilters, TipSortParams};
 
 #[tracing::instrument(skip(state), fields(username = %req.username, amount = %req.amount))]
 pub async fn record_tip(state: &AppState, req: RecordTipRequest) -> AppResult<Tip> {
@@ -148,34 +148,94 @@ pub async fn get_tips_for_creator(state: &AppState, username: &str) -> AppResult
 
 pub async fn get_tips_paginated(
     state: &AppState,
-    username: &str,
+    username: Option<&str>,
     params: PaginationParams,
+    filters: TipFilters,
+    sort: TipSortParams,
 ) -> AppResult<PaginatedResponse<Tip>> {
     let params = params.validated();
+    let (sort_col, sort_dir) = sort.validated();
 
-    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tips WHERE creator_username = $1")
-        .bind(username)
+    // Extract filter values up front so we can reference them multiple times.
+    let min_amount = filters.min_amount.as_deref();
+    let max_amount = filters.max_amount.as_deref();
+    let from_date = filters.from_date;
+    let to_date = filters.to_date;
+
+    let mut conditions: Vec<String> = Vec::new();
+    let mut bind_idx: i32 = 1;
+
+    if username.is_some() {
+        conditions.push(format!("creator_username = ${bind_idx}"));
+        bind_idx += 1;
+    }
+    if min_amount.is_some() {
+        conditions.push(format!("amount::numeric >= ${}::numeric", bind_idx));
+        bind_idx += 1;
+    }
+    if max_amount.is_some() {
+        conditions.push(format!("amount::numeric <= ${}::numeric", bind_idx));
+        bind_idx += 1;
+    }
+    if from_date.is_some() {
+        conditions.push(format!("created_at >= ${bind_idx}"));
+        bind_idx += 1;
+    }
+    if to_date.is_some() {
+        conditions.push(format!("created_at <= ${bind_idx}"));
+        bind_idx += 1;
+    }
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
+
+    let count_sql = format!("SELECT COUNT(*) FROM tips {where_clause}");
+    let data_sql = format!(
+        "SELECT id, creator_username, amount, transaction_hash, message, created_at \
+         FROM tips {where_clause} \
+         ORDER BY {sort_col} {sort_dir} \
+         LIMIT ${bind_idx} OFFSET ${}",
+        bind_idx + 1
+    );
+
+    // Bind all active filter parameters onto a query builder.
+    macro_rules! bind_filters {
+        ($q:expr) => {{
+            let mut q = $q;
+            if let Some(u) = username {
+                q = q.bind(u);
+            }
+            if let Some(v) = min_amount {
+                q = q.bind(v);
+            }
+            if let Some(v) = max_amount {
+                q = q.bind(v);
+            }
+            if let Some(v) = from_date {
+                q = q.bind(v);
+            }
+            if let Some(v) = to_date {
+                q = q.bind(v);
+            }
+            q
+        }};
+    }
+
+    let total: i64 = bind_filters!(sqlx::query_scalar(&count_sql))
         .fetch_one(&state.db)
         .await?;
 
     let start = Instant::now();
-    let tips = sqlx::query_as::<_, Tip>(
-        r#"
-        SELECT id, creator_username, amount, transaction_hash, message, created_at
-        FROM tips
-        WHERE creator_username = $1
-        ORDER BY created_at DESC
-        LIMIT $2 OFFSET $3
-        "#,
-    )
-    .bind(username)
-    .bind(params.limit)
-    .bind(params.offset())
-    .fetch_all(&state.db)
-    .await?;
+    let tips: Vec<Tip> = bind_filters!(sqlx::query_as::<_, Tip>(&data_sql))
+        .bind(params.limit)
+        .bind(params.offset())
+        .fetch_all(&state.db)
+        .await?;
     let duration = start.elapsed();
 
-    // Record your Prometheus metric for paginated queries too
     DB_QUERY_DURATION_SECONDS.observe(duration.as_secs_f64());
 
     Ok(PaginatedResponse::new(tips, total, &params))

--- a/src/models/pagination.rs
+++ b/src/models/pagination.rs
@@ -67,4 +67,16 @@ impl<T: Serialize> PaginatedResponse<T> {
             total_pages,
         }
     }
+
+    pub fn map<U: Serialize, F: Fn(T) -> U>(self, f: F) -> PaginatedResponse<U> {
+        PaginatedResponse {
+            data: self.data.into_iter().map(f).collect(),
+            total: self.total,
+            page: self.page,
+            limit: self.limit,
+            total_pages: self.total_pages,
+            has_next: self.has_next,
+            has_prev: self.has_prev,
+        }
+    }
 }

--- a/src/models/tip.rs
+++ b/src/models/tip.rs
@@ -48,6 +48,62 @@ fn validate_tx_hash(hash: &str) -> Result<(), validator::ValidationError> {
     Ok(())
 }
 
+/// Query filters for listing tips
+#[derive(Debug, Default, Deserialize, utoipa::IntoParams)]
+pub struct TipFilters {
+    /// Filter by minimum amount (inclusive)
+    pub min_amount: Option<String>,
+    /// Filter by maximum amount (inclusive)
+    pub max_amount: Option<String>,
+    /// Filter tips created on or after this timestamp (RFC 3339)
+    pub from_date: Option<DateTime<Utc>>,
+    /// Filter tips created on or before this timestamp (RFC 3339)
+    pub to_date: Option<DateTime<Utc>>,
+}
+
+/// Sort parameters for listing tips
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct TipSortParams {
+    /// Field to sort by: `created_at` or `amount` (default: `created_at`)
+    #[serde(default = "TipSortParams::default_sort_by")]
+    pub sort_by: String,
+    /// Sort direction: `asc` or `desc` (default: `desc`)
+    #[serde(default = "TipSortParams::default_sort_order")]
+    pub sort_order: String,
+}
+
+impl Default for TipSortParams {
+    fn default() -> Self {
+        Self {
+            sort_by: Self::default_sort_by(),
+            sort_order: Self::default_sort_order(),
+        }
+    }
+}
+
+impl TipSortParams {
+    fn default_sort_by() -> String {
+        "created_at".to_string()
+    }
+    fn default_sort_order() -> String {
+        "desc".to_string()
+    }
+
+    /// Returns a validated (column, direction) pair safe for interpolation.
+    pub fn validated(&self) -> (&'static str, &'static str) {
+        let col = match self.sort_by.as_str() {
+            "amount" => "amount::numeric",
+            _ => "created_at",
+        };
+        let dir = if self.sort_order.eq_ignore_ascii_case("asc") {
+            "ASC"
+        } else {
+            "DESC"
+        };
+        (col, dir)
+    }
+}
+
 /// Tip record response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct TipResponse {

--- a/src/routes/creators.rs
+++ b/src/routes/creators.rs
@@ -13,7 +13,7 @@ use crate::db::connection::AppState;
 use crate::errors::{AppError, ValidationError};
 use crate::models::creator::{CreateCreatorRequest, CreatorResponse};
 use crate::models::pagination::PaginationParams;
-use crate::models::tip::TipResponse;
+use crate::models::tip::{TipFilters, TipResponse, TipSortParams};
 use crate::search::SearchQuery;
 
 /// Write routes: POST /creators — subject to stricter rate limiting.
@@ -91,10 +91,12 @@ pub async fn get_creator_tips(
     State(state): State<Arc<AppState>>,
     Path(username): Path<String>,
     Query(params): Query<PaginationParams>,
+    Query(filters): Query<TipFilters>,
+    Query(sort): Query<TipSortParams>,
 ) -> Result<impl IntoResponse, AppError> {
-    let _ = params;
-    let tips = tip_controller::get_tips_for_creator(&state, &username).await?;
-    let response: Vec<TipResponse> = tips.into_iter().map(Into::into).collect();
+    let result = tip_controller::get_tips_paginated(&state, Some(&username), params, filters, sort)
+        .await?;
+    let response = result.map(TipResponse::from);
     Ok((StatusCode::OK, Json(serde_json::json!(response))).into_response())
 }
 

--- a/src/routes/tips.rs
+++ b/src/routes/tips.rs
@@ -1,13 +1,15 @@
-use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Json, Router};
+use axum::{extract::{Query, State}, http::StatusCode, response::IntoResponse, routing::{get, post}, Json, Router};
 use std::sync::Arc;
 
 use crate::controllers::tip_controller;
 use crate::db::connection::AppState;
 use crate::errors::{AppError, StellarError};
-use crate::models::tip::{RecordTipRequest, TipResponse};
+use crate::models::pagination::PaginationParams;
+use crate::models::tip::{RecordTipRequest, TipFilters, TipResponse, TipSortParams};
 
 pub fn router() -> Router<Arc<AppState>> {
-    Router::new().route("/tips", post(record_tip))
+    Router::new()
+        .route("/tips", post(record_tip).get(list_tips))
 }
 
 /// Record a new tip (verifies transaction on the Stellar network first)
@@ -44,4 +46,26 @@ pub async fn record_tip(
     let tip = tip_controller::record_tip(&state, body).await?;
     let response: TipResponse = tip.into();
     Ok((StatusCode::CREATED, Json(serde_json::json!(response))).into_response())
+}
+
+/// List all tips with pagination, filtering, and sorting
+#[utoipa::path(
+    get,
+    path = "/tips",
+    tag = "tips",
+    params(PaginationParams, TipFilters, TipSortParams),
+    responses(
+        (status = 200, description = "Paginated list of tips"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn list_tips(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<PaginationParams>,
+    Query(filters): Query<TipFilters>,
+    Query(sort): Query<TipSortParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let result = tip_controller::get_tips_paginated(&state, None, params, filters, sort).await?;
+    let response = result.map(TipResponse::from);
+    Ok((StatusCode::OK, Json(serde_json::json!(response))).into_response())
 }

--- a/tests/tips_test.rs
+++ b/tests/tips_test.rs
@@ -96,7 +96,108 @@ async fn test_get_tips_for_creator() {
     response.assert_status(StatusCode::OK);
 
     let body = response.json::<serde_json::Value>();
-    assert_eq!(body[0]["amount"], "5.5");
+    assert_eq!(body["data"][0]["amount"], "5.5");
+
+    common::cleanup_test_db(&pool).await;
+}
+
+#[tokio::test]
+async fn test_get_creator_tips_paginated() {
+    let pool = common::setup_test_db().await;
+    let (app, _) = common::create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    server
+        .post("/creators")
+        .json(&json!({ "username": "paguser", "wallet_address": "GPAG000", "email": null }))
+        .await;
+
+    for i in 1..=5i32 {
+        sqlx::query(
+            "INSERT INTO tips (id, creator_username, amount, transaction_hash, created_at) \
+             VALUES ($1, $2, $3, $4, NOW())",
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind("paguser")
+        .bind(format!("{}.0", i))
+        .bind(format!("HASH{i}"))
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    // Page 1, limit 2
+    let resp = server
+        .get("/creators/paguser/tips?page=1&limit=2")
+        .await;
+    resp.assert_status(StatusCode::OK);
+    let body = resp.json::<serde_json::Value>();
+    assert_eq!(body["data"].as_array().unwrap().len(), 2);
+    assert_eq!(body["total"], 5);
+    assert_eq!(body["total_pages"], 3);
+    assert_eq!(body["has_next"], true);
+    assert_eq!(body["has_prev"], false);
+
+    // Page 3 (last page, 1 item)
+    let resp = server
+        .get("/creators/paguser/tips?page=3&limit=2")
+        .await;
+    resp.assert_status(StatusCode::OK);
+    let body = resp.json::<serde_json::Value>();
+    assert_eq!(body["data"].as_array().unwrap().len(), 1);
+    assert_eq!(body["has_next"], false);
+    assert_eq!(body["has_prev"], true);
+
+    common::cleanup_test_db(&pool).await;
+}
+
+#[tokio::test]
+async fn test_list_tips_with_filters() {
+    let pool = common::setup_test_db().await;
+    let (app, _) = common::create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    server
+        .post("/creators")
+        .json(&json!({ "username": "filtuser", "wallet_address": "GFLT000", "email": null }))
+        .await;
+
+    for (amount, hash) in [("5.0", "FHASH1"), ("15.0", "FHASH2"), ("25.0", "FHASH3")] {
+        sqlx::query(
+            "INSERT INTO tips (id, creator_username, amount, transaction_hash, created_at) \
+             VALUES ($1, $2, $3, $4, NOW())",
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind("filtuser")
+        .bind(amount)
+        .bind(hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    // Filter min_amount=10
+    let resp = server
+        .get("/tips?min_amount=10&sort_by=amount&sort_order=asc")
+        .await;
+    resp.assert_status(StatusCode::OK);
+    let body = resp.json::<serde_json::Value>();
+    let data = body["data"].as_array().unwrap();
+    assert_eq!(data.len(), 2);
+    assert_eq!(data[0]["amount"], "15.0");
+    assert_eq!(data[1]["amount"], "25.0");
+
+    // Filter max_amount=10
+    let resp = server.get("/tips?max_amount=10").await;
+    resp.assert_status(StatusCode::OK);
+    let body = resp.json::<serde_json::Value>();
+    assert_eq!(body["total"], 1);
+
+    // Enforce max limit
+    let resp = server.get("/tips?limit=999").await;
+    resp.assert_status(StatusCode::OK);
+    let body = resp.json::<serde_json::Value>();
+    assert_eq!(body["limit"], 100);
 
     common::cleanup_test_db(&pool).await;
 }


### PR DESCRIPTION
## Summary

Implements pagination, filtering, and sorting for list endpoints (closes #106).

## Changes

**`src/models/tip.rs`**
- Added `TipFilters`: optional `min_amount`, `max_amount`, `from_date`, `to_date` query params
- Added `TipSortParams`: `sort_by` (`created_at` | `amount`) and `sort_order` (`asc` | `desc`) with whitelist validation to prevent SQL injection

**`src/models/pagination.rs`**
- Added `PaginatedResponse::map` helper for converting inner item types

**`src/controllers/tip_controller.rs`**
- `get_tips_paginated` now accepts `username: Option<&str>`, `TipFilters`, and `TipSortParams`
- Dynamically builds parameterized WHERE clause (no string interpolation of user values)
- Sort column/direction are whitelisted before interpolation

**`src/routes/creators.rs`**
- `GET /creators/:username/tips` now returns `PaginatedResponse<TipResponse>` with full pagination metadata

**`src/routes/tips.rs`**
- Added `GET /tips` endpoint for listing all tips with filter/sort/pagination

**`tests/tips_test.rs`**
- Fixed existing assertion for new paginated response shape
- Added tests: pagination (page/limit/total/has_next/has_prev), filters (min/max amount), max limit enforcement