### PR TITLE
feat: SQL injection prevention, CORS hardening, secrets management, tip validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,19 @@ STELLAR_NETWORK=testnet
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 PORT=8000
 
+# Vault secrets management (optional — falls back to env vars above when unset)
+# VAULT_ADDR=http://vault:8200
+# VAULT_TOKEN=<vault-token>
+# VAULT_MOUNT=secret          # KV v2 mount path (default: secret)
+# VAULT_PATH=stellar-tipjar   # Secret path within the mount
+
+# Tip amount limits (XLM)
+TIP_MIN_XLM=0.01
+TIP_MAX_XLM=10000
+
+# Comma-separated list of allowed CORS origins (no wildcards in production)
+ALLOWED_ORIGINS=http://localhost:3000
+
 # Redis (optional — caching is skipped gracefully if unavailable)
 REDIS_URL=redis://127.0.0.1:6379
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ hmac = "0.12"
 hex = "0.4"
 base64 = "0.22"
 urlencoding = "2"
+rust_decimal = "1"
 utoipa = { version = "4", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
 async-graphql = { version = "7", features = ["uuid", "chrono", "dataloader"] }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,1 +1,2 @@
 pub mod cors;
+pub mod secrets;

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -1,0 +1,119 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::RwLock;
+
+/// Resolved application secrets, sourced from Vault or environment variables.
+pub struct AppSecrets {
+    pub database_url: String,
+    pub stellar_rpc_url: String,
+    pub stellar_network: String,
+}
+
+struct CacheEntry {
+    value: String,
+    fetched_at: Instant,
+}
+
+pub struct SecretsManager {
+    /// Base URL of the Vault server, e.g. `http://vault:8200`.
+    vault_addr: Option<String>,
+    /// Vault token for authentication.
+    vault_token: Option<String>,
+    /// Mount path for the KV v2 secrets engine.
+    vault_mount: String,
+    /// Secret path within the mount, e.g. `stellar-tipjar`.
+    vault_path: String,
+    http: reqwest::Client,
+    cache: Arc<RwLock<HashMap<String, CacheEntry>>>,
+    ttl: Duration,
+}
+
+impl SecretsManager {
+    pub fn new() -> Self {
+        Self {
+            vault_addr: std::env::var("VAULT_ADDR").ok(),
+            vault_token: std::env::var("VAULT_TOKEN").ok(),
+            vault_mount: std::env::var("VAULT_MOUNT").unwrap_or_else(|_| "secret".to_string()),
+            vault_path: std::env::var("VAULT_PATH").unwrap_or_else(|_| "stellar-tipjar".to_string()),
+            http: reqwest::Client::new(),
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            ttl: Duration::from_secs(300),
+        }
+    }
+
+    /// Fetch a single key from Vault KV v2, with in-memory TTL caching.
+    async fn vault_get(&self, key: &str) -> Option<String> {
+        let (addr, token) = (self.vault_addr.as_ref()?, self.vault_token.as_ref()?);
+
+        // Check cache first.
+        {
+            let cache = self.cache.read().await;
+            if let Some(entry) = cache.get(key) {
+                if entry.fetched_at.elapsed() < self.ttl {
+                    return Some(entry.value.clone());
+                }
+            }
+        }
+
+        let url = format!(
+            "{}/v1/{}/data/{}",
+            addr, self.vault_mount, self.vault_path
+        );
+
+        let resp = self
+            .http
+            .get(&url)
+            .header("X-Vault-Token", token)
+            .send()
+            .await
+            .ok()?;
+
+        if !resp.status().is_success() {
+            tracing::warn!(url = %url, status = %resp.status(), "Vault request failed");
+            return None;
+        }
+
+        let body: serde_json::Value = resp.json().await.ok()?;
+        let value = body["data"]["data"][key].as_str()?.to_string();
+
+        tracing::info!(key = %key, "Secret fetched from Vault");
+
+        let mut cache = self.cache.write().await;
+        cache.insert(
+            key.to_string(),
+            CacheEntry { value: value.clone(), fetched_at: Instant::now() },
+        );
+
+        Some(value)
+    }
+
+    /// Resolve a secret: try Vault first, fall back to the environment variable.
+    async fn resolve(&self, vault_key: &str, env_var: &str) -> anyhow::Result<String> {
+        if let Some(v) = self.vault_get(vault_key).await {
+            return Ok(v);
+        }
+        std::env::var(env_var).map_err(|_| {
+            anyhow::anyhow!(
+                "Secret '{}' not found in Vault and env var '{}' is not set",
+                vault_key,
+                env_var
+            )
+        })
+    }
+
+    pub async fn load(&self) -> anyhow::Result<AppSecrets> {
+        Ok(AppSecrets {
+            database_url: self.resolve("DATABASE_URL", "DATABASE_URL").await?,
+            stellar_rpc_url: self
+                .resolve("STELLAR_RPC_URL", "STELLAR_RPC_URL")
+                .await
+                .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string()),
+            stellar_network: self
+                .resolve("STELLAR_NETWORK", "STELLAR_NETWORK")
+                .await
+                .unwrap_or_else(|_| "testnet".to_string()),
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,14 @@
 use axum::Router;
-use axum::{http::Method, Router};
 use sqlx::postgres::PgPoolOptions;
 use std::sync::Arc;
 use tokio::sync::broadcast;
-use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 mod analytics;
 mod cache;
+mod config;
 mod controllers;
 mod cqrs;
 mod db;
@@ -50,11 +49,13 @@ async fn main() -> anyhow::Result<()> {
 
     logging::init();
 
-    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    let stellar_rpc_url = std::env::var("STELLAR_RPC_URL")
-        .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string());
-    let stellar_network =
-        std::env::var("STELLAR_NETWORK").unwrap_or_else(|_| "testnet".to_string());
+    // --- Secrets Resolution ---
+    // Loads from Vault (if VAULT_ADDR + VAULT_TOKEN are set) with env-var fallback.
+    let secrets = config::secrets::SecretsManager::new().load().await?;
+    let database_url = secrets.database_url;
+    let stellar_rpc_url = secrets.stellar_rpc_url;
+    let stellar_network = secrets.stellar_network;
+
 
     let pool = PgPoolOptions::new()
         .max_connections(20)
@@ -101,10 +102,7 @@ async fn main() -> anyhow::Result<()> {
     // Start background job processing system
     let (_job_queue, _job_scheduler) = jobs::start(Arc::clone(&state), jobs::JobConfig::default());
 
-    let cors = CorsLayer::new()
-        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
-        .allow_origin(Any)
-        .allow_headers(Any);
+    let cors = middleware::cors::cors_layer();
 
     // Build rate limiters (Your FIXED version - no tuples!)
     let general_limiter_v1 = middleware::rate_limiter::general_limiter();
@@ -169,6 +167,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(v2)
         .layer(axum::Extension(gql_schema))
         .layer(cors)
+        .layer(axum::middleware::map_response(middleware::cors::security_headers))
         .layer(TraceLayer::new_for_http())
         .layer(axum::middleware::from_fn(
             middleware::tracing::trace_request,

--- a/src/middleware/cors.rs
+++ b/src/middleware/cors.rs
@@ -1,0 +1,55 @@
+use std::time::Duration;
+
+use axum::http::{HeaderName, HeaderValue, Method, Response};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+pub fn cors_layer() -> CorsLayer {
+    let allowed_origins = std::env::var("ALLOWED_ORIGINS")
+        .unwrap_or_else(|_| "http://localhost:3000".to_string());
+
+    let origins: Vec<HeaderValue> = allowed_origins
+        .split(',')
+        .filter_map(|s| HeaderValue::from_str(s.trim()).ok())
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(origins))
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([
+            axum::http::header::CONTENT_TYPE,
+            axum::http::header::AUTHORIZATION,
+            axum::http::header::ACCEPT,
+        ])
+        .allow_credentials(true)
+        .max_age(Duration::from_secs(3600))
+}
+
+pub async fn security_headers<B>(response: Response<B>) -> Response<B> {
+    let (mut parts, body) = response.into_parts();
+    let h = &mut parts.headers;
+
+    h.insert(
+        HeaderName::from_static("content-security-policy"),
+        HeaderValue::from_static("default-src 'self'"),
+    );
+    h.insert(
+        HeaderName::from_static("strict-transport-security"),
+        HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    );
+    h.insert(
+        HeaderName::from_static("x-frame-options"),
+        HeaderValue::from_static("DENY"),
+    );
+    h.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+
+    Response::from_parts(parts, body)
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod authorization;
 pub mod cache;
 pub mod compression;
+pub mod cors;
 pub mod deprecation;
 pub mod metrics;
 pub mod rate_limiter;

--- a/src/models/tip.rs
+++ b/src/models/tip.rs
@@ -1,8 +1,14 @@
 use chrono::{DateTime, Utc};
+use lazy_static::lazy_static;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 use validator::Validate;
+
+lazy_static! {
+    static ref USERNAME_REGEX: Regex = Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Tip {
@@ -23,6 +29,7 @@ pub struct RecordTipRequest {
         max = 30,
         message = "Username must be between 3 and 30 characters"
     ))]
+    #[validate(regex(path = *USERNAME_REGEX, message = "Username may only contain letters, numbers, underscores, and hyphens"))]
     pub username: String,
 
     /// Amount in XLM (e.g. "10.5"), positive, max 7 decimal places

--- a/src/routes/tips.rs
+++ b/src/routes/tips.rs
@@ -6,6 +6,7 @@ use crate::db::connection::AppState;
 use crate::errors::{AppError, StellarError};
 use crate::models::pagination::PaginationParams;
 use crate::models::tip::{RecordTipRequest, TipFilters, TipResponse, TipSortParams};
+use crate::services::validation_service::{TipValidationService, ValidationRules};
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -29,6 +30,9 @@ pub async fn record_tip(
     State(state): State<Arc<AppState>>,
     crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<RecordTipRequest>,
 ) -> Result<impl IntoResponse, AppError> {
+    let validator = TipValidationService::new(ValidationRules::default());
+    validator.validate(&state.db, &body).await?;
+
     match state
         .stellar
         .verify_transaction(&body.transaction_hash)

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,3 +4,4 @@ pub mod creator_service;
 pub mod retry;
 pub mod stellar_service;
 pub mod tip_service;
+pub mod validation_service;

--- a/src/services/validation_service.rs
+++ b/src/services/validation_service.rs
@@ -1,0 +1,122 @@
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use std::str::FromStr;
+
+use crate::errors::{AppError, AppResult};
+use crate::models::tip::RecordTipRequest;
+
+/// Configurable limits for tip validation. Defaults are loaded from environment
+/// variables so they can be tuned without recompiling.
+pub struct ValidationRules {
+    pub min_tip_xlm: Decimal,
+    pub max_tip_xlm: Decimal,
+}
+
+impl Default for ValidationRules {
+    fn default() -> Self {
+        let min = std::env::var("TIP_MIN_XLM")
+            .ok()
+            .and_then(|v| Decimal::from_str(&v).ok())
+            .unwrap_or_else(|| Decimal::from_str("0.01").unwrap());
+        let max = std::env::var("TIP_MAX_XLM")
+            .ok()
+            .and_then(|v| Decimal::from_str(&v).ok())
+            .unwrap_or_else(|| Decimal::from_str("10000").unwrap());
+        Self { min_tip_xlm: min, max_tip_xlm: max }
+    }
+}
+
+pub struct TipValidationService {
+    rules: ValidationRules,
+}
+
+impl TipValidationService {
+    pub fn new(rules: ValidationRules) -> Self {
+        Self { rules }
+    }
+
+    /// Run all business-logic checks before a tip is persisted.
+    /// Call this after input validation (ValidatedJson) but before Stellar verification.
+    pub async fn validate(&self, pool: &PgPool, req: &RecordTipRequest) -> AppResult<()> {
+        self.check_amount(&req.amount)?;
+        self.check_duplicate(pool, &req.transaction_hash).await?;
+        self.check_creator_exists(pool, &req.username).await?;
+        self.check_fraud_indicators(pool, req).await;
+        Ok(())
+    }
+
+    fn check_amount(&self, amount: &str) -> AppResult<()> {
+        let value = Decimal::from_str(amount).map_err(|_| AppError::Conflict {
+            code: "INVALID_AMOUNT",
+            message: "Tip amount is not a valid decimal".to_string(),
+        })?;
+
+        if value < self.rules.min_tip_xlm {
+            return Err(AppError::Conflict {
+                code: "AMOUNT_TOO_LOW",
+                message: format!("Minimum tip amount is {} XLM", self.rules.min_tip_xlm),
+            });
+        }
+        if value > self.rules.max_tip_xlm {
+            return Err(AppError::Conflict {
+                code: "AMOUNT_TOO_HIGH",
+                message: format!("Maximum tip amount is {} XLM", self.rules.max_tip_xlm),
+            });
+        }
+        Ok(())
+    }
+
+    async fn check_duplicate(&self, pool: &PgPool, tx_hash: &str) -> AppResult<()> {
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM tips WHERE transaction_hash = $1)")
+                .bind(tx_hash)
+                .fetch_one(pool)
+                .await?;
+
+        if exists {
+            return Err(AppError::Conflict {
+                code: "DUPLICATE_TRANSACTION",
+                message: "This transaction has already been recorded".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn check_creator_exists(&self, pool: &PgPool, username: &str) -> AppResult<()> {
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM creators WHERE username = $1)")
+                .bind(username)
+                .fetch_one(pool)
+                .await?;
+
+        if !exists {
+            return Err(AppError::CreatorNotFound { username: username.to_string() });
+        }
+        Ok(())
+    }
+
+    /// Logs a warning when the same amount has been tipped to the same creator
+    /// more than 5 times in the last hour — a heuristic fraud signal.
+    async fn check_fraud_indicators(&self, pool: &PgPool, req: &RecordTipRequest) {
+        let result: Result<i64, _> = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM tips \
+             WHERE creator_username = $1 AND amount = $2 \
+             AND created_at > NOW() - INTERVAL '1 hour'",
+        )
+        .bind(&req.username)
+        .bind(&req.amount)
+        .fetch_one(pool)
+        .await;
+
+        if let Ok(count) = result {
+            if count > 5 {
+                tracing::warn!(
+                    creator = %req.username,
+                    amount = %req.amount,
+                    count = count,
+                    "Fraud signal: repeated same-amount tips within 1 hour"
+                );
+            }
+        }
+    }
+}

--- a/tests/security_test.rs
+++ b/tests/security_test.rs
@@ -1,0 +1,100 @@
+use axum::http::StatusCode;
+use axum_test::TestServer;
+use serde_json::json;
+mod common;
+
+/// All SQL injection payloads must be rejected at the validation layer (400)
+/// or return no data (404) — never a 500 or unexpected data leak.
+#[tokio::test]
+async fn test_sql_injection_in_username_path() {
+    let pool = common::setup_test_db().await;
+    let (app, _) = common::create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    let payloads = [
+        "' OR '1'='1",
+        "'; DROP TABLE creators; --",
+        "1' UNION SELECT * FROM creators--",
+        "admin'--",
+    ];
+
+    for payload in payloads {
+        let response = server.get(&format!("/creators/{}", payload)).await;
+        // Must not be a server error — injection was either rejected or returned not-found
+        assert_ne!(
+            response.status_code(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Payload caused 500: {payload}"
+        );
+        assert_ne!(
+            response.status_code(),
+            StatusCode::OK,
+            "Payload unexpectedly matched a creator: {payload}"
+        );
+    }
+
+    common::cleanup_test_db(&pool).await;
+}
+
+#[tokio::test]
+async fn test_sql_injection_in_create_creator_body() {
+    let pool = common::setup_test_db().await;
+    let (app, _) = common::create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    let payloads = [
+        "'; DROP TABLE creators; --",
+        "admin' OR '1'='1",
+        "x' UNION SELECT id,username,wallet_address,email,created_at FROM creators--",
+    ];
+
+    for payload in payloads {
+        let response = server
+            .post("/creators")
+            .json(&json!({
+                "username": payload,
+                "wallet_address": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+            }))
+            .await;
+
+        // Validation layer must reject these with 422 (ValidatedJson)
+        assert_eq!(
+            response.status_code(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Expected 422 for injection payload: {payload}"
+        );
+    }
+
+    common::cleanup_test_db(&pool).await;
+}
+
+#[tokio::test]
+async fn test_sql_injection_in_record_tip_body() {
+    let pool = common::setup_test_db().await;
+    let (app, _) = common::create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    let payloads = [
+        "'; DROP TABLE tips; --",
+        "admin' OR '1'='1",
+    ];
+
+    for payload in payloads {
+        let response = server
+            .post("/tips")
+            .json(&json!({
+                "username": payload,
+                "amount": "10.0",
+                "transaction_hash": "a".repeat(64)
+            }))
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Expected 422 for injection payload: {payload}"
+        );
+    }
+
+    common::cleanup_test_db(&pool).await;
+}


### PR DESCRIPTION


- #125: Add username allowlist regex to RecordTipRequest; add security injection tests
- #126: Replace permissive CORS with origin allowlist from ALLOWED_ORIGINS env var; add security headers middleware (CSP, HSTS, X-Frame-Options, X-Content-Type-Options)
- #127: Add SecretsManager with Vault KV v2 support, TTL cache, and env-var fallback
- #128: Add TipValidationService with amount limits, duplicate detection, creator existence check, and fraud heuristic logging
Closes #125 
Closes #126 
Closes #127 
Closes #128 