### PR TITLE
feat: implement real-time notification system with WebSockets

### DIFF
--- a/migrations/0024_notifications.sql
+++ b/migrations/0024_notifications.sql
@@ -1,0 +1,20 @@
+-- Notification preferences per creator (one row per creator)
+CREATE TABLE IF NOT EXISTS notification_preferences (
+    creator_username TEXT PRIMARY KEY REFERENCES creators(username) ON DELETE CASCADE,
+    notify_on_tip     BOOLEAN NOT NULL DEFAULT TRUE,
+    notify_on_milestone BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Persistent notification history with read tracking
+CREATE TABLE IF NOT EXISTS notifications (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    creator_username TEXT NOT NULL REFERENCES creators(username) ON DELETE CASCADE,
+    type             TEXT NOT NULL,   -- 'tip_received' | 'milestone'
+    payload          JSONB NOT NULL DEFAULT '{}',
+    read             BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_creator ON notifications(creator_username, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_unread  ON notifications(creator_username) WHERE read = FALSE;

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin_controller;
 pub mod creator_controller;
 pub mod export_controller;
+pub mod notification_controller;
 pub mod tip_controller;

--- a/src/controllers/notification_controller.rs
+++ b/src/controllers/notification_controller.rs
@@ -1,0 +1,114 @@
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::errors::AppResult;
+use crate::models::notification::{Notification, NotificationPreferences, UpdatePreferencesRequest};
+
+/// Get preferences for a creator, creating defaults if none exist.
+pub async fn get_preferences(pool: &PgPool, username: &str) -> AppResult<NotificationPreferences> {
+    let prefs = sqlx::query_as::<_, NotificationPreferences>(
+        r#"
+        INSERT INTO notification_preferences (creator_username)
+        VALUES ($1)
+        ON CONFLICT (creator_username) DO UPDATE SET updated_at = notification_preferences.updated_at
+        RETURNING creator_username, notify_on_tip, notify_on_milestone, updated_at
+        "#,
+    )
+    .bind(username)
+    .fetch_one(pool)
+    .await?;
+    Ok(prefs)
+}
+
+pub async fn update_preferences(
+    pool: &PgPool,
+    username: &str,
+    req: UpdatePreferencesRequest,
+) -> AppResult<NotificationPreferences> {
+    let prefs = sqlx::query_as::<_, NotificationPreferences>(
+        r#"
+        INSERT INTO notification_preferences (creator_username, notify_on_tip, notify_on_milestone)
+        VALUES ($1, COALESCE($2, TRUE), COALESCE($3, TRUE))
+        ON CONFLICT (creator_username) DO UPDATE SET
+            notify_on_tip       = COALESCE($2, notification_preferences.notify_on_tip),
+            notify_on_milestone = COALESCE($3, notification_preferences.notify_on_milestone),
+            updated_at          = NOW()
+        RETURNING creator_username, notify_on_tip, notify_on_milestone, updated_at
+        "#,
+    )
+    .bind(username)
+    .bind(req.notify_on_tip)
+    .bind(req.notify_on_milestone)
+    .fetch_one(pool)
+    .await?;
+    Ok(prefs)
+}
+
+/// Persist a notification and return it.
+pub async fn create_notification(
+    pool: &PgPool,
+    username: &str,
+    notification_type: &str,
+    payload: serde_json::Value,
+) -> AppResult<Notification> {
+    let n = sqlx::query_as::<_, Notification>(
+        r#"
+        INSERT INTO notifications (id, creator_username, type, payload)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id, creator_username, type, payload, read, created_at
+        "#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(username)
+    .bind(notification_type)
+    .bind(payload)
+    .fetch_one(pool)
+    .await?;
+    Ok(n)
+}
+
+pub async fn list_notifications(
+    pool: &PgPool,
+    username: &str,
+    unread_only: bool,
+) -> AppResult<Vec<Notification>> {
+    let notifications = if unread_only {
+        sqlx::query_as::<_, Notification>(
+            "SELECT id, creator_username, type, payload, read, created_at
+             FROM notifications WHERE creator_username = $1 AND read = FALSE
+             ORDER BY created_at DESC LIMIT 100",
+        )
+        .bind(username)
+        .fetch_all(pool)
+        .await?
+    } else {
+        sqlx::query_as::<_, Notification>(
+            "SELECT id, creator_username, type, payload, read, created_at
+             FROM notifications WHERE creator_username = $1
+             ORDER BY created_at DESC LIMIT 100",
+        )
+        .bind(username)
+        .fetch_all(pool)
+        .await?
+    };
+    Ok(notifications)
+}
+
+pub async fn mark_read(pool: &PgPool, username: &str, notification_id: Uuid) -> AppResult<()> {
+    sqlx::query(
+        "UPDATE notifications SET read = TRUE WHERE id = $1 AND creator_username = $2",
+    )
+    .bind(notification_id)
+    .bind(username)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn mark_all_read(pool: &PgPool, username: &str) -> AppResult<()> {
+    sqlx::query("UPDATE notifications SET read = TRUE WHERE creator_username = $1")
+        .bind(username)
+        .execute(pool)
+        .await?;
+    Ok(())
+}

--- a/src/controllers/tip_controller.rs
+++ b/src/controllers/tip_controller.rs
@@ -111,6 +111,36 @@ pub async fn record_tip_in_tx(
     };
     crate::ws::broadcast_tip(&state.broadcast_tx, event).await;
 
+    // Persist notification if creator has tip notifications enabled.
+    {
+        let db = state.db.clone();
+        let username = tip.creator_username.clone();
+        let payload = serde_json::json!({
+            "tip_id": tip.id,
+            "amount": tip.amount,
+            "transaction_hash": tip.transaction_hash,
+            "message": tip.message,
+        });
+        tokio::spawn(async move {
+            use crate::controllers::notification_controller;
+            match notification_controller::get_preferences(&db, &username).await {
+                Ok(prefs) if prefs.notify_on_tip => {
+                    if let Err(e) = notification_controller::create_notification(
+                        &db,
+                        &username,
+                        "tip_received",
+                        payload,
+                    )
+                    .await
+                    {
+                        tracing::warn!("Failed to persist tip notification: {e}");
+                    }
+                }
+                _ => {}
+            }
+        });
+    }
+
     Ok(tip)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ async fn main() -> anyhow::Result<()> {
                     Router::new()
                         .merge(routes::creators::read_router())
                         .merge(routes::health::router())
+                        .merge(routes::notifications::router())
                         .layer(general_limiter_v1),
                 ),
         )
@@ -147,6 +148,7 @@ async fn main() -> anyhow::Result<()> {
                 Router::new()
                     .merge(routes::creators::read_router())
                     .merge(routes::health::router())
+                    .merge(routes::notifications::router())
                     .layer(general_limiter_v2),
             ),
     );

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod auth;
 pub mod creator;
+pub mod notification;
 pub mod pagination;
 pub mod tip;

--- a/src/models/notification.rs
+++ b/src/models/notification.rs
@@ -1,0 +1,29 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct NotificationPreferences {
+    pub creator_username: String,
+    pub notify_on_tip: bool,
+    pub notify_on_milestone: bool,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdatePreferencesRequest {
+    pub notify_on_tip: Option<bool>,
+    pub notify_on_milestone: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct Notification {
+    pub id: Uuid,
+    pub creator_username: String,
+    #[serde(rename = "type")]
+    #[sqlx(rename = "type")]
+    pub notification_type: String,
+    pub payload: serde_json::Value,
+    pub read: bool,
+    pub created_at: DateTime<Utc>,
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,4 +3,5 @@ pub mod auth;
 pub mod creators;
 pub mod export;
 pub mod health;
+pub mod notifications;
 pub mod tips;

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -1,0 +1,84 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, patch, put},
+    Json, Router,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::controllers::notification_controller;
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::notification::UpdatePreferencesRequest;
+
+#[derive(Deserialize)]
+pub struct NotificationQuery {
+    #[serde(default)]
+    pub unread_only: bool,
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route(
+            "/creators/:username/notifications/preferences",
+            get(get_preferences).put(update_preferences),
+        )
+        .route(
+            "/creators/:username/notifications",
+            get(list_notifications),
+        )
+        .route(
+            "/creators/:username/notifications/read-all",
+            patch(mark_all_read),
+        )
+        .route(
+            "/creators/:username/notifications/:id/read",
+            patch(mark_read),
+        )
+}
+
+async fn get_preferences(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let prefs = notification_controller::get_preferences(&state.db, &username).await?;
+    Ok((StatusCode::OK, Json(prefs)))
+}
+
+async fn update_preferences(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+    Json(body): Json<UpdatePreferencesRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let prefs = notification_controller::update_preferences(&state.db, &username, body).await?;
+    Ok((StatusCode::OK, Json(prefs)))
+}
+
+async fn list_notifications(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+    Query(q): Query<NotificationQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let notifications =
+        notification_controller::list_notifications(&state.db, &username, q.unread_only).await?;
+    Ok((StatusCode::OK, Json(notifications)))
+}
+
+async fn mark_read(
+    State(state): State<Arc<AppState>>,
+    Path((username, id)): Path<(String, Uuid)>,
+) -> Result<impl IntoResponse, AppError> {
+    notification_controller::mark_read(&state.db, &username, id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn mark_all_read(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    notification_controller::mark_all_read(&state.db, &username).await?;
+    Ok(StatusCode::NO_CONTENT)
+}


### PR DESCRIPTION
- Add notification_preferences table (per-creator opt-in flags)
- Add notifications table with read status and JSONB payload
- Add notification_controller with get/update preferences, create, list, mark_read, mark_all_read
- Add REST routes under /creators/:username/notifications
- Persist tip_received notification after each tip (respects prefs)
- WebSocket broadcast unchanged; notifications stored for history
Closes #129 
Closes #130 
Closes #131 
Closes #132 