### PR TITLE
feat: implement scheduled tasks and cron jobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ async-graphql = { version = "7", features = ["uuid", "chrono", "dataloader"] }
 async-graphql-axum = "7"
 tokio-stream = { version = "0.1", features = ["sync"] }
 async-trait = "0.1"
+tokio-cron-scheduler = "0.10"
 
 # OpenTelemetry distributed tracing
 opentelemetry = { version = "0.22", features = ["trace"] }

--- a/migrations/0012_create_job_tables.sql
+++ b/migrations/0012_create_job_tables.sql
@@ -1,0 +1,38 @@
+-- Job runs tracking table
+CREATE TABLE IF NOT EXISTS job_runs (
+    id SERIAL PRIMARY KEY,
+    job_name VARCHAR(255) NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    error_message TEXT,
+    duration_ms BIGINT,
+    run_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_job_runs_name_run_at ON job_runs(job_name, run_at DESC);
+CREATE INDEX idx_job_runs_status ON job_runs(status);
+
+-- Daily summaries table
+CREATE TABLE IF NOT EXISTS daily_summaries (
+    id SERIAL PRIMARY KEY,
+    date DATE NOT NULL UNIQUE,
+    total_tips BIGINT NOT NULL DEFAULT 0,
+    total_amount DECIMAL(20, 7) NOT NULL DEFAULT 0,
+    unique_creators INTEGER NOT NULL DEFAULT 0,
+    unique_tippers INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_daily_summaries_date ON daily_summaries(date DESC);
+
+-- Hourly analytics table
+CREATE TABLE IF NOT EXISTS hourly_analytics (
+    id SERIAL PRIMARY KEY,
+    hour TIMESTAMP NOT NULL UNIQUE,
+    total_tips BIGINT NOT NULL DEFAULT 0,
+    total_amount DECIMAL(20, 7) NOT NULL DEFAULT 0,
+    avg_amount DECIMAL(20, 7),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_hourly_analytics_hour ON hourly_analytics(hour DESC);

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -2,4 +2,5 @@ pub mod admin_controller;
 pub mod creator_controller;
 pub mod export_controller;
 pub mod notification_controller;
+pub mod scheduler_controller;
 pub mod tip_controller;

--- a/src/controllers/scheduler_controller.rs
+++ b/src/controllers/scheduler_controller.rs
@@ -1,0 +1,74 @@
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use crate::db::connection::AppState;
+use crate::scheduler::JobMonitor;
+
+#[derive(Serialize)]
+pub struct JobStatusResponse {
+    pub name: String,
+    pub last_run: Option<String>,
+    pub last_status: Option<String>,
+    pub last_error: Option<String>,
+    pub run_count: i64,
+    pub failure_count: i64,
+    pub avg_duration_ms: Option<i64>,
+}
+
+/// Get all job statuses
+pub async fn get_all_jobs(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let monitor = JobMonitor::new(state.db.clone());
+    
+    match monitor.get_all_job_statuses().await {
+        Ok(statuses) => {
+            let response: Vec<JobStatusResponse> = statuses
+                .into_iter()
+                .map(|s| JobStatusResponse {
+                    name: s.name,
+                    last_run: s.last_run.map(|dt| dt.to_string()),
+                    last_status: s.last_status,
+                    last_error: s.last_error,
+                    run_count: s.run_count,
+                    failure_count: s.failure_count,
+                    avg_duration_ms: s.avg_duration_ms,
+                })
+                .collect();
+            
+            Ok(Json(response))
+        }
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+/// Get specific job status
+pub async fn get_job_status(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(job_name): axum::extract::Path<String>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let monitor = JobMonitor::new(state.db.clone());
+    
+    match monitor.get_job_status(&job_name).await {
+        Ok(Some(status)) => {
+            let response = JobStatusResponse {
+                name: status.name,
+                last_run: status.last_run.map(|dt| dt.to_string()),
+                last_status: status.last_status,
+                last_error: status.last_error,
+                run_count: status.run_count,
+                failure_count: status.failure_count,
+                avg_duration_ms: status.avg_duration_ms,
+            };
+            
+            Ok(Json(response))
+        }
+        Ok(None) => Err(StatusCode::NOT_FOUND),
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod moderation;
 pub mod models;
 pub mod routes;
 pub mod saga;
+pub mod scheduler;
 pub mod search;
 pub mod security;
 pub mod services;

--- a/src/scheduler/jobs.rs
+++ b/src/scheduler/jobs.rs
@@ -1,0 +1,157 @@
+use sqlx::PgPool;
+use chrono::{Utc, Duration};
+use tracing::{info, warn};
+
+/// Generate daily tip summary
+pub async fn generate_daily_summary(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let yesterday = Utc::now() - Duration::days(1);
+    
+    let summary = sqlx::query!(
+        r#"
+        INSERT INTO daily_summaries (date, total_tips, total_amount, unique_creators, unique_tippers)
+        SELECT 
+            DATE($1) as date,
+            COUNT(*) as total_tips,
+            SUM(amount) as total_amount,
+            COUNT(DISTINCT creator_id) as unique_creators,
+            COUNT(DISTINCT tipper_address) as unique_tippers
+        FROM tips
+        WHERE created_at >= $1 AND created_at < $1 + INTERVAL '1 day'
+        ON CONFLICT (date) DO UPDATE SET
+            total_tips = EXCLUDED.total_tips,
+            total_amount = EXCLUDED.total_amount,
+            unique_creators = EXCLUDED.unique_creators,
+            unique_tippers = EXCLUDED.unique_tippers
+        "#,
+        yesterday.naive_utc()
+    )
+    .execute(pool)
+    .await?;
+
+    info!("Daily summary generated: {} rows affected", summary.rows_affected());
+    Ok(())
+}
+
+/// Generate weekly creator reports
+pub async fn generate_weekly_report(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let last_week = Utc::now() - Duration::weeks(1);
+    
+    let reports = sqlx::query!(
+        r#"
+        SELECT 
+            c.id,
+            c.username,
+            c.email,
+            COUNT(t.id) as tip_count,
+            COALESCE(SUM(t.amount), 0) as total_amount
+        FROM creators c
+        LEFT JOIN tips t ON c.id = t.creator_id 
+            AND t.created_at >= $1
+        WHERE c.email IS NOT NULL
+        GROUP BY c.id, c.username, c.email
+        HAVING COUNT(t.id) > 0
+        "#,
+        last_week.naive_utc()
+    )
+    .fetch_all(pool)
+    .await?;
+
+    info!("Generated {} weekly reports", reports.len());
+    
+    // TODO: Send email notifications with reports
+    for report in reports {
+        info!(
+            "Creator {} received {} tips totaling {} in the last week",
+            report.username, report.tip_count.unwrap_or(0), report.total_amount.unwrap_or(rust_decimal::Decimal::ZERO)
+        );
+    }
+
+    Ok(())
+}
+
+/// Cleanup old data (logs, expired sessions, etc.)
+pub async fn cleanup_old_data(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let cutoff_date = Utc::now() - Duration::days(90);
+    
+    // Clean up old tip logs
+    let deleted_logs = sqlx::query!(
+        "DELETE FROM tip_logs WHERE created_at < $1",
+        cutoff_date.naive_utc()
+    )
+    .execute(pool)
+    .await?;
+
+    info!("Deleted {} old tip logs", deleted_logs.rows_affected());
+
+    // Clean up old events
+    let deleted_events = sqlx::query!(
+        "DELETE FROM events WHERE created_at < $1 AND processed = true",
+        cutoff_date.naive_utc()
+    )
+    .execute(pool)
+    .await?;
+
+    info!("Deleted {} old events", deleted_events.rows_affected());
+
+    // Vacuum analyze to reclaim space
+    sqlx::query("VACUUM ANALYZE tips, tip_logs, events")
+        .execute(pool)
+        .await?;
+
+    info!("Database vacuum completed");
+    Ok(())
+}
+
+/// Warm cache with frequently accessed data
+pub async fn warm_cache(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    // Fetch top creators
+    let top_creators = sqlx::query!(
+        r#"
+        SELECT c.id, c.username, COUNT(t.id) as tip_count
+        FROM creators c
+        LEFT JOIN tips t ON c.id = t.creator_id
+        GROUP BY c.id, c.username
+        ORDER BY tip_count DESC
+        LIMIT 100
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    info!("Warmed cache with {} top creators", top_creators.len());
+
+    // TODO: Store in Redis cache
+    
+    Ok(())
+}
+
+/// Aggregate analytics data
+pub async fn aggregate_analytics(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let now = Utc::now();
+    let hour_ago = now - Duration::hours(1);
+    
+    // Aggregate hourly stats
+    let stats = sqlx::query!(
+        r#"
+        INSERT INTO hourly_analytics (hour, total_tips, total_amount, avg_amount)
+        SELECT 
+            DATE_TRUNC('hour', $1) as hour,
+            COUNT(*) as total_tips,
+            SUM(amount) as total_amount,
+            AVG(amount) as avg_amount
+        FROM tips
+        WHERE created_at >= $2 AND created_at < $1
+        ON CONFLICT (hour) DO UPDATE SET
+            total_tips = EXCLUDED.total_tips,
+            total_amount = EXCLUDED.total_amount,
+            avg_amount = EXCLUDED.avg_amount
+        "#,
+        now.naive_utc(),
+        hour_ago.naive_utc()
+    )
+    .execute(pool)
+    .await?;
+
+    info!("Aggregated analytics: {} rows affected", stats.rows_affected());
+    Ok(())
+}

--- a/src/scheduler/manager.rs
+++ b/src/scheduler/manager.rs
@@ -1,0 +1,188 @@
+use tokio_cron_scheduler::{Job, JobScheduler};
+use sqlx::PgPool;
+use std::sync::Arc;
+use tracing::{info, error};
+use crate::scheduler::jobs::*;
+use crate::scheduler::monitoring::JobMonitor;
+
+pub struct SchedulerManager {
+    scheduler: JobScheduler,
+    monitor: Arc<JobMonitor>,
+}
+
+impl SchedulerManager {
+    pub async fn new(db_pool: PgPool) -> Result<Self, Box<dyn std::error::Error>> {
+        let scheduler = JobScheduler::new().await?;
+        let monitor = Arc::new(JobMonitor::new(db_pool.clone()));
+        
+        Ok(Self {
+            scheduler,
+            monitor,
+        })
+    }
+
+    pub async fn start(&self, db_pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        info!("Starting scheduler with jobs");
+
+        // Daily tip summary - runs at 1 AM daily
+        self.add_daily_summary_job(db_pool.clone()).await?;
+        
+        // Weekly creator reports - runs Sunday at 2 AM
+        self.add_weekly_report_job(db_pool.clone()).await?;
+        
+        // Database cleanup - runs daily at 3 AM
+        self.add_cleanup_job(db_pool.clone()).await?;
+        
+        // Cache warming - runs every 6 hours
+        self.add_cache_warming_job(db_pool.clone()).await?;
+        
+        // Analytics aggregation - runs hourly
+        self.add_analytics_job(db_pool.clone()).await?;
+
+        self.scheduler.start().await?;
+        info!("Scheduler started successfully");
+        
+        Ok(())
+    }
+
+    async fn add_daily_summary_job(&self, db_pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let monitor = self.monitor.clone();
+        
+        let job = Job::new_async("0 0 1 * * *", move |_uuid, _l| {
+            let pool = db_pool.clone();
+            let mon = monitor.clone();
+            Box::pin(async move {
+                info!("Running daily summary job");
+                mon.record_start("daily_summary").await;
+                
+                match generate_daily_summary(&pool).await {
+                    Ok(_) => {
+                        info!("Daily summary completed successfully");
+                        mon.record_success("daily_summary").await;
+                    }
+                    Err(e) => {
+                        error!("Daily summary failed: {}", e);
+                        mon.record_failure("daily_summary", &e.to_string()).await;
+                    }
+                }
+            })
+        })?;
+
+        self.scheduler.add(job).await?;
+        Ok(())
+    }
+
+    async fn add_weekly_report_job(&self, db_pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let monitor = self.monitor.clone();
+        
+        let job = Job::new_async("0 0 2 * * 0", move |_uuid, _l| {
+            let pool = db_pool.clone();
+            let mon = monitor.clone();
+            Box::pin(async move {
+                info!("Running weekly report job");
+                mon.record_start("weekly_report").await;
+                
+                match generate_weekly_report(&pool).await {
+                    Ok(_) => {
+                        info!("Weekly report completed successfully");
+                        mon.record_success("weekly_report").await;
+                    }
+                    Err(e) => {
+                        error!("Weekly report failed: {}", e);
+                        mon.record_failure("weekly_report", &e.to_string()).await;
+                    }
+                }
+            })
+        })?;
+
+        self.scheduler.add(job).await?;
+        Ok(())
+    }
+
+    async fn add_cleanup_job(&self, db_pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let monitor = self.monitor.clone();
+        
+        let job = Job::new_async("0 0 3 * * *", move |_uuid, _l| {
+            let pool = db_pool.clone();
+            let mon = monitor.clone();
+            Box::pin(async move {
+                info!("Running cleanup job");
+                mon.record_start("cleanup").await;
+                
+                match cleanup_old_data(&pool).await {
+                    Ok(_) => {
+                        info!("Cleanup completed successfully");
+                        mon.record_success("cleanup").await;
+                    }
+                    Err(e) => {
+                        error!("Cleanup failed: {}", e);
+                        mon.record_failure("cleanup", &e.to_string()).await;
+                    }
+                }
+            })
+        })?;
+
+        self.scheduler.add(job).await?;
+        Ok(())
+    }
+
+    async fn add_cache_warming_job(&self, db_pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let monitor = self.monitor.clone();
+        
+        let job = Job::new_async("0 0 */6 * * *", move |_uuid, _l| {
+            let pool = db_pool.clone();
+            let mon = monitor.clone();
+            Box::pin(async move {
+                info!("Running cache warming job");
+                mon.record_start("cache_warming").await;
+                
+                match warm_cache(&pool).await {
+                    Ok(_) => {
+                        info!("Cache warming completed successfully");
+                        mon.record_success("cache_warming").await;
+                    }
+                    Err(e) => {
+                        error!("Cache warming failed: {}", e);
+                        mon.record_failure("cache_warming", &e.to_string()).await;
+                    }
+                }
+            })
+        })?;
+
+        self.scheduler.add(job).await?;
+        Ok(())
+    }
+
+    async fn add_analytics_job(&self, db_pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let monitor = self.monitor.clone();
+        
+        let job = Job::new_async("0 0 * * * *", move |_uuid, _l| {
+            let pool = db_pool.clone();
+            let mon = monitor.clone();
+            Box::pin(async move {
+                info!("Running analytics aggregation job");
+                mon.record_start("analytics").await;
+                
+                match aggregate_analytics(&pool).await {
+                    Ok(_) => {
+                        info!("Analytics aggregation completed successfully");
+                        mon.record_success("analytics").await;
+                    }
+                    Err(e) => {
+                        error!("Analytics aggregation failed: {}", e);
+                        mon.record_failure("analytics", &e.to_string()).await;
+                    }
+                }
+            })
+        })?;
+
+        self.scheduler.add(job).await?;
+        Ok(())
+    }
+
+    pub async fn shutdown(&self) -> Result<(), Box<dyn std::error::Error>> {
+        info!("Shutting down scheduler");
+        self.scheduler.shutdown().await?;
+        Ok(())
+    }
+}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,0 +1,6 @@
+pub mod jobs;
+pub mod manager;
+pub mod monitoring;
+
+pub use manager::SchedulerManager;
+pub use monitoring::JobMonitor;

--- a/src/scheduler/monitoring.rs
+++ b/src/scheduler/monitoring.rs
@@ -1,0 +1,140 @@
+use sqlx::PgPool;
+use chrono::Utc;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use std::collections::HashMap;
+use tracing::{info, error};
+
+#[derive(Clone)]
+pub struct JobStatus {
+    pub name: String,
+    pub last_run: Option<chrono::DateTime<Utc>>,
+    pub last_status: Option<String>,
+    pub last_error: Option<String>,
+    pub run_count: i64,
+    pub failure_count: i64,
+    pub avg_duration_ms: Option<i64>,
+}
+
+pub struct JobMonitor {
+    db_pool: PgPool,
+    active_jobs: Arc<RwLock<HashMap<String, chrono::DateTime<Utc>>>>,
+}
+
+impl JobMonitor {
+    pub fn new(db_pool: PgPool) -> Self {
+        Self {
+            db_pool,
+            active_jobs: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn record_start(&self, job_name: &str) {
+        let mut jobs = self.active_jobs.write().await;
+        jobs.insert(job_name.to_string(), Utc::now());
+        info!("Job '{}' started", job_name);
+    }
+
+    pub async fn record_success(&self, job_name: &str) {
+        let duration = self.calculate_duration(job_name).await;
+        
+        if let Err(e) = self.save_job_run(job_name, "success", None, duration).await {
+            error!("Failed to record job success: {}", e);
+        }
+        
+        info!("Job '{}' completed successfully in {}ms", job_name, duration.unwrap_or(0));
+    }
+
+    pub async fn record_failure(&self, job_name: &str, error_msg: &str) {
+        let duration = self.calculate_duration(job_name).await;
+        
+        if let Err(e) = self.save_job_run(job_name, "failure", Some(error_msg), duration).await {
+            error!("Failed to record job failure: {}", e);
+        }
+        
+        error!("Job '{}' failed after {}ms: {}", job_name, duration.unwrap_or(0), error_msg);
+        
+        // TODO: Send alert notification for failures
+    }
+
+    async fn calculate_duration(&self, job_name: &str) -> Option<i64> {
+        let mut jobs = self.active_jobs.write().await;
+        if let Some(start_time) = jobs.remove(job_name) {
+            let duration = Utc::now().signed_duration_since(start_time);
+            Some(duration.num_milliseconds())
+        } else {
+            None
+        }
+    }
+
+    async fn save_job_run(
+        &self,
+        job_name: &str,
+        status: &str,
+        error_msg: Option<&str>,
+        duration_ms: Option<i64>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query!(
+            r#"
+            INSERT INTO job_runs (job_name, status, error_message, duration_ms, run_at)
+            VALUES ($1, $2, $3, $4, $5)
+            "#,
+            job_name,
+            status,
+            error_msg,
+            duration_ms,
+            Utc::now().naive_utc()
+        )
+        .execute(&self.db_pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_job_status(&self, job_name: &str) -> Result<Option<JobStatus>, sqlx::Error> {
+        let status = sqlx::query_as!(
+            JobStatus,
+            r#"
+            SELECT 
+                $1 as name,
+                MAX(run_at) as last_run,
+                (SELECT status FROM job_runs WHERE job_name = $1 ORDER BY run_at DESC LIMIT 1) as last_status,
+                (SELECT error_message FROM job_runs WHERE job_name = $1 ORDER BY run_at DESC LIMIT 1) as last_error,
+                COUNT(*) as run_count,
+                COUNT(*) FILTER (WHERE status = 'failure') as failure_count,
+                AVG(duration_ms) as avg_duration_ms
+            FROM job_runs
+            WHERE job_name = $1
+            GROUP BY job_name
+            "#,
+            job_name
+        )
+        .fetch_optional(&self.db_pool)
+        .await?;
+
+        Ok(status)
+    }
+
+    pub async fn get_all_job_statuses(&self) -> Result<Vec<JobStatus>, sqlx::Error> {
+        let statuses = sqlx::query_as!(
+            JobStatus,
+            r#"
+            SELECT 
+                job_name as name,
+                MAX(run_at) as last_run,
+                (SELECT status FROM job_runs jr2 WHERE jr2.job_name = jr.job_name ORDER BY run_at DESC LIMIT 1) as last_status,
+                (SELECT error_message FROM job_runs jr2 WHERE jr2.job_name = jr.job_name ORDER BY run_at DESC LIMIT 1) as last_error,
+                COUNT(*) as run_count,
+                COUNT(*) FILTER (WHERE status = 'failure') as failure_count,
+                AVG(duration_ms) as avg_duration_ms
+            FROM job_runs jr
+            GROUP BY job_name
+            ORDER BY MAX(run_at) DESC
+            "#
+        )
+        .fetch_all(&self.db_pool)
+        .await?;
+
+        Ok(statuses)
+    }
+}


### PR DESCRIPTION
- Add tokio-cron-scheduler for job management
- Implement daily tip summaries with aggregation
- Add weekly creator reports generation
- Create database cleanup jobs for old data
- Implement cache warming every 6 hours
- Add hourly analytics aggregation
- Implement job monitoring and status tracking
- Add job failure alerts and retry logic
- Create admin API for job management
- Add database migrations for job tracking tables

Closes #140