### PR TITLE
feat: chaos engineering framework, transaction wrappers, and db retry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 reqwest = { version = "0.12", features = ["json"] }
 thiserror = "1"
 anyhow = "1"
-validator = { version = "0.18", features = ["derive", "email"] }
+validator = { version = "0.18", features = ["derive"] }
 bcrypt = "0.15"
 jsonwebtoken = "9"
 regex = "1"
@@ -67,4 +67,4 @@ tower = "0.4"
 httpmock = "0.7"
 proptest = "1.4"
 criterion = "0.5"
-tarpaulin = "0.27"
+# tarpaulin = "0.27"  # not a library crate; use `cargo tarpaulin` CLI instead

--- a/src/chaos/experiments.rs
+++ b/src/chaos/experiments.rs
@@ -1,0 +1,203 @@
+use std::time::Duration;
+
+use super::injectors::{ChaosInjector, Result};
+use super::metrics::{Metrics, MetricsCollector};
+use super::ChaosError;
+
+/// Result of a single chaos experiment run.
+#[derive(Debug)]
+pub struct ExperimentResult {
+    pub name: String,
+    pub baseline: Metrics,
+    pub chaos_metrics: Metrics,
+    pub recovery_metrics: Metrics,
+    /// `true` when the system met all resilience thresholds.
+    pub passed: bool,
+}
+
+/// Thresholds used to evaluate whether an experiment passed.
+#[derive(Debug, Clone)]
+pub struct ResilienceThresholds {
+    /// Maximum acceptable error rate during chaos (e.g. 0.05 = 5 %).
+    pub max_error_rate_during_chaos: f64,
+    /// Maximum acceptable p99 latency multiplier vs baseline.
+    pub max_latency_multiplier: f64,
+    /// Maximum acceptable error rate after recovery (relative to baseline).
+    pub max_recovery_error_rate_multiplier: f64,
+}
+
+impl Default for ResilienceThresholds {
+    fn default() -> Self {
+        Self {
+            max_error_rate_during_chaos: 0.05,
+            max_latency_multiplier: 2.0,
+            max_recovery_error_rate_multiplier: 1.1,
+        }
+    }
+}
+
+/// A single chaos experiment: inject failures, observe, recover, evaluate.
+pub struct ChaosExperiment {
+    pub name: String,
+    pub injectors: Vec<Box<dyn ChaosInjector>>,
+    pub duration: Duration,
+    pub thresholds: ResilienceThresholds,
+}
+
+impl ChaosExperiment {
+    pub fn new(name: impl Into<String>, duration: Duration) -> Self {
+        Self {
+            name: name.into(),
+            injectors: Vec::new(),
+            duration,
+            thresholds: ResilienceThresholds::default(),
+        }
+    }
+
+    pub fn with_injector(mut self, injector: Box<dyn ChaosInjector>) -> Self {
+        self.injectors.push(injector);
+        self
+    }
+
+    pub fn with_thresholds(mut self, thresholds: ResilienceThresholds) -> Self {
+        self.thresholds = thresholds;
+        self
+    }
+
+    /// Run the experiment: baseline → inject → chaos window → recover → evaluate.
+    pub async fn run(
+        &self,
+        baseline_collector: &mut MetricsCollector,
+        chaos_collector: &mut MetricsCollector,
+        recovery_collector: &mut MetricsCollector,
+    ) -> Result<ExperimentResult> {
+        tracing::info!(experiment = %self.name, "Chaos experiment starting");
+
+        let baseline = baseline_collector.snapshot();
+
+        // Inject all failures.
+        for injector in &self.injectors {
+            injector.inject().await?;
+        }
+
+        tokio::time::sleep(self.duration).await;
+        let chaos_metrics = chaos_collector.snapshot();
+
+        // Recover.
+        for injector in &self.injectors {
+            injector.recover().await?;
+        }
+
+        // Allow system to stabilise.
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let recovery_metrics = recovery_collector.snapshot();
+
+        let passed = self.evaluate(&baseline, &chaos_metrics, &recovery_metrics);
+
+        tracing::info!(
+            experiment = %self.name,
+            passed,
+            chaos_error_rate = chaos_metrics.error_rate,
+            "Chaos experiment complete"
+        );
+
+        Ok(ExperimentResult {
+            name: self.name.clone(),
+            baseline,
+            chaos_metrics,
+            recovery_metrics,
+            passed,
+        })
+    }
+
+    fn evaluate(&self, baseline: &Metrics, chaos: &Metrics, recovery: &Metrics) -> bool {
+        let error_ok = chaos.error_rate < self.thresholds.max_error_rate_during_chaos;
+
+        let latency_ok = baseline.p99_latency_ms == 0.0
+            || chaos.p99_latency_ms
+                < baseline.p99_latency_ms * self.thresholds.max_latency_multiplier;
+
+        let recovery_ok = recovery.error_rate
+            < baseline.error_rate * self.thresholds.max_recovery_error_rate_multiplier + 0.01;
+
+        error_ok && latency_ok && recovery_ok
+    }
+}
+
+/// Runs multiple experiments sequentially and produces a summary report.
+pub struct ChaosRunner {
+    pub cool_down: Duration,
+}
+
+impl Default for ChaosRunner {
+    fn default() -> Self {
+        Self { cool_down: Duration::from_secs(10) }
+    }
+}
+
+impl ChaosRunner {
+    pub fn new(cool_down: Duration) -> Self {
+        Self { cool_down }
+    }
+
+    pub async fn run_all(
+        &self,
+        experiments: Vec<(
+            ChaosExperiment,
+            MetricsCollector,
+            MetricsCollector,
+            MetricsCollector,
+        )>,
+    ) -> Result<Vec<ExperimentResult>> {
+        let mut results = Vec::new();
+
+        for (experiment, mut baseline, mut chaos, mut recovery) in experiments {
+            let result = experiment.run(&mut baseline, &mut chaos, &mut recovery).await?;
+            results.push(result);
+            tokio::time::sleep(self.cool_down).await;
+        }
+
+        Ok(results)
+    }
+
+    pub fn generate_report(&self, results: &[ExperimentResult]) -> String {
+        let passed = results.iter().filter(|r| r.passed).count();
+        let total = results.len();
+        let mut report = format!(
+            "# Chaos Engineering Report\n\nPassed: {}/{}\n\n",
+            passed, total
+        );
+
+        for r in results {
+            let status = if r.passed { "✅ PASS" } else { "❌ FAIL" };
+            report.push_str(&format!(
+                "## {} — {}\n\
+                 - Chaos error rate:    {:.2}%\n\
+                 - Chaos p99 latency:   {:.1}ms\n\
+                 - Recovery error rate: {:.2}%\n\n",
+                r.name,
+                status,
+                r.chaos_metrics.error_rate * 100.0,
+                r.chaos_metrics.p99_latency_ms,
+                r.recovery_metrics.error_rate * 100.0,
+            ));
+        }
+
+        report
+    }
+}
+
+/// Convenience: assert all experiments passed (for use in tests).
+pub fn assert_all_passed(results: &[ExperimentResult]) {
+    let failures: Vec<&str> = results
+        .iter()
+        .filter(|r| !r.passed)
+        .map(|r| r.name.as_str())
+        .collect();
+
+    assert!(
+        failures.is_empty(),
+        "Chaos experiments failed: {:?}",
+        failures
+    );
+}

--- a/src/chaos/injectors.rs
+++ b/src/chaos/injectors.rs
@@ -1,0 +1,184 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use super::ChaosError;
+
+pub type Result<T> = std::result::Result<T, ChaosError>;
+
+#[async_trait]
+pub trait ChaosInjector: Send + Sync {
+    async fn inject(&self) -> Result<()>;
+    async fn recover(&self) -> Result<()>;
+}
+
+// ── Latency injector ──────────────────────────────────────────────────────────
+
+pub struct LatencyInjector {
+    pub target_service: String,
+    pub latency: Duration,
+    active: Arc<AtomicBool>,
+}
+
+impl LatencyInjector {
+    pub fn new(target_service: impl Into<String>, latency: Duration) -> Self {
+        Self {
+            target_service: target_service.into(),
+            latency,
+            active: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    /// Applies the configured delay if injection is active.
+    pub async fn maybe_delay(&self) {
+        if self.is_active() {
+            tokio::time::sleep(self.latency).await;
+        }
+    }
+}
+
+#[async_trait]
+impl ChaosInjector for LatencyInjector {
+    async fn inject(&self) -> Result<()> {
+        self.active.store(true, Ordering::SeqCst);
+        tracing::warn!(
+            target = %self.target_service,
+            latency_ms = self.latency.as_millis(),
+            "Chaos: latency injection active"
+        );
+        Ok(())
+    }
+
+    async fn recover(&self) -> Result<()> {
+        self.active.store(false, Ordering::SeqCst);
+        tracing::info!(target = %self.target_service, "Chaos: latency injection removed");
+        Ok(())
+    }
+}
+
+// ── Database failure injector ─────────────────────────────────────────────────
+
+pub struct DatabaseFailureInjector {
+    pub failure_rate: f64,
+    active: Arc<AtomicBool>,
+}
+
+impl DatabaseFailureInjector {
+    pub fn new(failure_rate: f64) -> Self {
+        Self {
+            failure_rate: failure_rate.clamp(0.0, 1.0),
+            active: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Returns `Err` with the configured probability when injection is active.
+    pub fn maybe_fail(&self) -> Result<()> {
+        if self.active.load(Ordering::SeqCst) && rand_f64() < self.failure_rate {
+            return Err(ChaosError::InjectedFailure("database".into()));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ChaosInjector for DatabaseFailureInjector {
+    async fn inject(&self) -> Result<()> {
+        self.active.store(true, Ordering::SeqCst);
+        tracing::warn!(failure_rate = self.failure_rate, "Chaos: database failure injection active");
+        Ok(())
+    }
+
+    async fn recover(&self) -> Result<()> {
+        self.active.store(false, Ordering::SeqCst);
+        tracing::info!("Chaos: database failure injection removed");
+        Ok(())
+    }
+}
+
+// ── Network partition injector ────────────────────────────────────────────────
+
+pub struct NetworkPartitionInjector {
+    pub target: String,
+    active: Arc<AtomicBool>,
+}
+
+impl NetworkPartitionInjector {
+    pub fn new(target: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+            active: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn is_partitioned(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ChaosInjector for NetworkPartitionInjector {
+    async fn inject(&self) -> Result<()> {
+        self.active.store(true, Ordering::SeqCst);
+        tracing::warn!(target = %self.target, "Chaos: network partition active");
+        Ok(())
+    }
+
+    async fn recover(&self) -> Result<()> {
+        self.active.store(false, Ordering::SeqCst);
+        tracing::info!(target = %self.target, "Chaos: network partition removed");
+        Ok(())
+    }
+}
+
+// ── Service crash injector ────────────────────────────────────────────────────
+
+pub struct ServiceCrashInjector {
+    pub service_name: String,
+    crashed: Arc<AtomicBool>,
+}
+
+impl ServiceCrashInjector {
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            crashed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn is_crashed(&self) -> bool {
+        self.crashed.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ChaosInjector for ServiceCrashInjector {
+    async fn inject(&self) -> Result<()> {
+        self.crashed.store(true, Ordering::SeqCst);
+        tracing::warn!(service = %self.service_name, "Chaos: service crash simulated");
+        Ok(())
+    }
+
+    async fn recover(&self) -> Result<()> {
+        self.crashed.store(false, Ordering::SeqCst);
+        tracing::info!(service = %self.service_name, "Chaos: service restarted");
+        Ok(())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Simple LCG-based pseudo-random f64 in [0, 1) without pulling in `rand`.
+fn rand_f64() -> f64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let seed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(42);
+    (seed as f64) / (u32::MAX as f64)
+}

--- a/src/chaos/metrics.rs
+++ b/src/chaos/metrics.rs
@@ -1,0 +1,89 @@
+use std::time::{Duration, Instant};
+
+/// Snapshot of system health metrics collected during an experiment phase.
+#[derive(Debug, Clone, Default)]
+pub struct Metrics {
+    /// Fraction of requests that returned an error (0.0–1.0).
+    pub error_rate: f64,
+    /// 99th-percentile latency in milliseconds.
+    pub p99_latency_ms: f64,
+    /// Number of successful operations observed.
+    pub success_count: u64,
+    /// Number of failed operations observed.
+    pub failure_count: u64,
+}
+
+impl Metrics {
+    pub fn total(&self) -> u64 {
+        self.success_count + self.failure_count
+    }
+}
+
+/// Collects latency samples and computes summary statistics.
+#[derive(Debug, Default)]
+pub struct MetricsCollector {
+    samples: Vec<Duration>,
+    errors: u64,
+}
+
+impl MetricsCollector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_success(&mut self, latency: Duration) {
+        self.samples.push(latency);
+    }
+
+    pub fn record_error(&mut self) {
+        self.errors += 1;
+    }
+
+    /// Snapshot current state as a `Metrics` value.
+    pub fn snapshot(&mut self) -> Metrics {
+        let total = self.samples.len() as u64 + self.errors;
+        let error_rate = if total == 0 {
+            0.0
+        } else {
+            self.errors as f64 / total as f64
+        };
+
+        let p99 = percentile_ms(&mut self.samples, 99);
+
+        Metrics {
+            error_rate,
+            p99_latency_ms: p99,
+            success_count: self.samples.len() as u64,
+            failure_count: self.errors,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.samples.clear();
+        self.errors = 0;
+    }
+}
+
+/// Measures elapsed time for a synchronous block.
+pub struct LatencyTimer {
+    start: Instant,
+}
+
+impl LatencyTimer {
+    pub fn start() -> Self {
+        Self { start: Instant::now() }
+    }
+
+    pub fn elapsed(self) -> Duration {
+        self.start.elapsed()
+    }
+}
+
+fn percentile_ms(samples: &mut Vec<Duration>, p: usize) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    samples.sort_unstable();
+    let idx = ((p as f64 / 100.0) * (samples.len() - 1) as f64).round() as usize;
+    samples[idx].as_secs_f64() * 1000.0
+}

--- a/src/chaos/mod.rs
+++ b/src/chaos/mod.rs
@@ -1,0 +1,12 @@
+pub mod experiments;
+pub mod injectors;
+pub mod metrics;
+pub mod scenarios;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChaosError {
+    #[error("injected failure: {0}")]
+    InjectedFailure(String),
+    #[error("experiment setup error: {0}")]
+    Setup(String),
+}

--- a/src/chaos/scenarios.rs
+++ b/src/chaos/scenarios.rs
@@ -1,0 +1,66 @@
+use std::time::Duration;
+
+use super::experiments::ChaosExperiment;
+use super::injectors::{
+    DatabaseFailureInjector, LatencyInjector, NetworkPartitionInjector, ServiceCrashInjector,
+};
+
+/// Pre-built scenarios that cover the most common failure modes.
+pub struct ChaosScenarios;
+
+impl ChaosScenarios {
+    /// Simulates a complete database outage (100 % failure rate).
+    pub fn database_outage() -> ChaosExperiment {
+        ChaosExperiment::new("Database Outage", Duration::from_secs(30))
+            .with_injector(Box::new(DatabaseFailureInjector::new(1.0)))
+    }
+
+    /// Simulates intermittent database failures (50 % failure rate).
+    pub fn database_flakiness() -> ChaosExperiment {
+        ChaosExperiment::new("Database Flakiness", Duration::from_secs(30))
+            .with_injector(Box::new(DatabaseFailureInjector::new(0.5)))
+    }
+
+    /// Simulates a network partition to the Stellar Horizon API.
+    pub fn stellar_network_partition() -> ChaosExperiment {
+        ChaosExperiment::new("Stellar Network Partition", Duration::from_secs(30))
+            .with_injector(Box::new(NetworkPartitionInjector::new("stellar-horizon")))
+    }
+
+    /// Simulates high latency on the database connection (500 ms).
+    pub fn high_database_latency() -> ChaosExperiment {
+        ChaosExperiment::new("High Database Latency", Duration::from_secs(30))
+            .with_injector(Box::new(LatencyInjector::new(
+                "database",
+                Duration::from_millis(500),
+            )))
+    }
+
+    /// Simulates a crash of the tip-processing service.
+    pub fn tip_service_crash() -> ChaosExperiment {
+        ChaosExperiment::new("Tip Service Crash", Duration::from_secs(15))
+            .with_injector(Box::new(ServiceCrashInjector::new("tip-service")))
+    }
+
+    /// Combined scenario: high latency + partial database failures.
+    pub fn degraded_mode() -> ChaosExperiment {
+        ChaosExperiment::new("Degraded Mode", Duration::from_secs(30))
+            .with_injector(Box::new(LatencyInjector::new(
+                "database",
+                Duration::from_millis(200),
+            )))
+            .with_injector(Box::new(DatabaseFailureInjector::new(0.2)))
+    }
+
+    /// Returns all standard scenarios for a full resilience suite.
+    pub fn all() -> Vec<ChaosExperiment> {
+        vec![
+            Self::database_outage(),
+            Self::database_flakiness(),
+            Self::stellar_network_partition(),
+            Self::high_database_latency(),
+            Self::tip_service_crash(),
+            Self::degraded_mode(),
+        ]
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -6,5 +6,6 @@ pub mod query_analyzer;
 pub mod query_cache;
 pub mod query_logger;
 pub mod query_optimizer;
+pub mod retry;
 pub mod slow_query_logger;
 pub mod transaction;

--- a/src/db/retry.rs
+++ b/src/db/retry.rs
@@ -1,0 +1,111 @@
+use std::future::Future;
+use std::time::Duration;
+
+use sqlx::PgPool;
+
+/// Retry a database operation on deadlock or serialization failures.
+///
+/// Uses exponential backoff starting at 100 ms, doubling each attempt.
+/// Non-retryable errors are returned immediately.
+pub async fn with_db_retry<F, T, E>(
+    pool: &PgPool,
+    max_retries: u32,
+    f: F,
+) -> Result<T, E>
+where
+    F: Fn(&PgPool) -> std::pin::Pin<Box<dyn Future<Output = Result<T, E>> + Send>>,
+    E: From<sqlx::Error> + std::fmt::Debug,
+{
+    let mut attempts = 0u32;
+
+    loop {
+        match f(pool).await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                attempts += 1;
+                if attempts > max_retries || !is_retryable(&e) {
+                    return Err(e);
+                }
+                let delay = Duration::from_millis(100 * 2u64.saturating_pow(attempts - 1));
+                tracing::warn!(
+                    attempt = attempts,
+                    max = max_retries,
+                    error = ?e,
+                    "Retryable DB error, backing off {:?}",
+                    delay
+                );
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+fn is_retryable<E: std::fmt::Debug>(error: &E) -> bool {
+    let s = format!("{:?}", error);
+    s.contains("deadlock")
+        || s.contains("serialization failure")
+        || s.contains("could not serialize")
+        || s.contains("40001") // PostgreSQL serialization_failure SQLSTATE
+        || s.contains("40P01") // PostgreSQL deadlock_detected SQLSTATE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn retries_on_retryable_error() {
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = counter.clone();
+
+        // Simulate a pool — we won't actually connect, just test retry logic.
+        // We use a dummy pool URL that will fail to connect; the closure never
+        // uses the pool, so this is fine for unit-testing the retry loop.
+        let pool = sqlx::PgPool::connect_lazy("postgres://localhost/nonexistent").unwrap();
+
+        let result: Result<(), String> = with_db_retry(&pool, 2, |_pool| {
+            let c = c.clone();
+            Box::pin(async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Err("deadlock detected".to_string())
+            })
+        })
+        .await;
+
+        assert!(result.is_err());
+        // initial attempt + 2 retries = 3 total
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_non_retryable_error() {
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = counter.clone();
+
+        let pool = sqlx::PgPool::connect_lazy("postgres://localhost/nonexistent").unwrap();
+
+        let result: Result<(), String> = with_db_retry(&pool, 3, |_pool| {
+            let c = c.clone();
+            Box::pin(async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Err("unique constraint violation".to_string())
+            })
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn succeeds_on_first_attempt() {
+        let pool = sqlx::PgPool::connect_lazy("postgres://localhost/nonexistent").unwrap();
+
+        let result: Result<u32, String> =
+            with_db_retry(&pool, 3, |_pool| Box::pin(async { Ok(42u32) })).await;
+
+        assert_eq!(result.unwrap(), 42);
+    }
+}

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -1,10 +1,60 @@
 use anyhow::Result;
-use sqlx::{Postgres, Transaction};
+use sqlx::{PgPool, Postgres, Transaction};
+use std::future::Future;
 
 /// A helper to begin a new database transaction.
 /// Rolls back automatically on drop if not committed.
 pub async fn begin_transaction(pool: &sqlx::PgPool) -> Result<Transaction<'_, Postgres>> {
     pool.begin().await.map_err(Into::into)
+}
+
+/// Runs `f` inside a transaction, committing on `Ok` and rolling back on `Err`.
+pub async fn with_transaction<F, T, E>(pool: &PgPool, f: F) -> std::result::Result<T, E>
+where
+    F: for<'a> FnOnce(
+        &'a mut Transaction<'_, Postgres>,
+    ) -> std::pin::Pin<Box<dyn Future<Output = std::result::Result<T, E>> + Send + 'a>>,
+    E: From<sqlx::Error>,
+{
+    let mut tx = pool.begin().await.map_err(E::from)?;
+    match f(&mut tx).await {
+        Ok(result) => {
+            tx.commit().await.map_err(E::from)?;
+            Ok(result)
+        }
+        Err(e) => {
+            let _ = tx.rollback().await;
+            Err(e)
+        }
+    }
+}
+
+/// Like `with_transaction` but sets `SERIALIZABLE` isolation before running `f`.
+pub async fn with_serializable_transaction<F, T, E>(
+    pool: &PgPool,
+    f: F,
+) -> std::result::Result<T, E>
+where
+    F: for<'a> FnOnce(
+        &'a mut Transaction<'_, Postgres>,
+    ) -> std::pin::Pin<Box<dyn Future<Output = std::result::Result<T, E>> + Send + 'a>>,
+    E: From<sqlx::Error>,
+{
+    let mut tx = pool.begin().await.map_err(E::from)?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .execute(&mut *tx)
+        .await
+        .map_err(E::from)?;
+    match f(&mut tx).await {
+        Ok(result) => {
+            tx.commit().await.map_err(E::from)?;
+            Ok(result)
+        }
+        Err(e) => {
+            let _ = tx.rollback().await;
+            Err(e)
+        }
+    }
 }
 
 /// Creates a new savepoint within an existing transaction to provide

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod analytics;
 pub mod cache;
+pub mod chaos;
 pub mod controllers;
 pub mod cqrs;
 pub mod db;

--- a/src/models/tip.rs
+++ b/src/models/tip.rs
@@ -21,7 +21,7 @@ pub struct Tip {
 }
 
 /// Request body for recording a tip
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
 pub struct RecordTipRequest {
     /// Username of the creator receiving the tip
     #[validate(length(

--- a/src/services/tip_service.rs
+++ b/src/services/tip_service.rs
@@ -1,5 +1,7 @@
 use crate::controllers::{creator_controller, tip_controller};
 use crate::db::connection::AppState;
+use crate::db::retry::with_db_retry;
+use crate::db::transaction::with_transaction;
 use crate::errors::{AppError, AppResult};
 use crate::models::tip::{RecordTipRequest, Tip};
 use std::sync::Arc;
@@ -38,38 +40,43 @@ impl TipService {
         state: &AppState,
         requests: Vec<RecordTipRequest>,
     ) -> AppResult<Vec<Tip>> {
-        let mut tx = crate::db::transaction::begin_transaction(&state.db)
-            .await
-            .map_err(AppError::from)?;
-        let mut results = Vec::new();
-
-        for (i, req) in requests.into_iter().enumerate() {
-            let sp = format!("tip_record_{}", i);
-            crate::db::transaction::create_savepoint(&mut tx, &sp)
+        let pool = state.db.clone();
+        with_db_retry(&pool, 3, |pool| {
+            let requests = requests.clone();
+            let state = state.clone();
+            Box::pin(async move {
+                with_transaction(pool, |tx| {
+                    Box::pin(async move {
+                        let mut results = Vec::new();
+                        for (i, req) in requests.into_iter().enumerate() {
+                            let sp = format!("tip_record_{}", i);
+                            crate::db::transaction::create_savepoint(tx, &sp)
+                                .await
+                                .map_err(AppError::from)?;
+                            match tip_controller::record_tip_in_tx(&state, tx, &req).await {
+                                Ok(tip) => {
+                                    results.push(tip);
+                                    crate::db::transaction::release_savepoint(tx, &sp)
+                                        .await
+                                        .map_err(AppError::from)?;
+                                }
+                                Err(e) => {
+                                    tracing::error!(
+                                        "Bulk tip record failed for index {}: {}. Rolling back savepoint.",
+                                        i, e
+                                    );
+                                    crate::db::transaction::rollback_savepoint(tx, &sp)
+                                        .await
+                                        .map_err(AppError::from)?;
+                                }
+                            }
+                        }
+                        Ok(results)
+                    })
+                })
                 .await
-                .map_err(AppError::from)?;
-
-            match tip_controller::record_tip_in_tx(&mut tx, &req).await {
-                Ok(tip) => {
-                    results.push(tip);
-                    crate::db::transaction::release_savepoint(&mut tx, &sp)
-                        .await
-                        .map_err(AppError::from)?;
-                }
-                Err(e) => {
-                    tracing::error!(
-                        "Bulk tip record failed for index {}: {}. Rolling back savepoint.",
-                        i,
-                        e
-                    );
-                    crate::db::transaction::rollback_savepoint(&mut tx, &sp)
-                        .await
-                        .map_err(AppError::from)?;
-                }
-            }
-        }
-
-        tx.commit().await?;
-        Ok(results)
+            })
+        })
+        .await
     }
 }

--- a/tests/chaos/mod.rs
+++ b/tests/chaos/mod.rs
@@ -1,0 +1,222 @@
+use std::time::Duration;
+
+use stellar_tipjar_backend::chaos::{
+    experiments::{assert_all_passed, ChaosExperiment, ChaosRunner, ResilienceThresholds},
+    injectors::{
+        ChaosInjector, DatabaseFailureInjector, LatencyInjector, NetworkPartitionInjector,
+        ServiceCrashInjector,
+    },
+    metrics::MetricsCollector,
+    scenarios::ChaosScenarios,
+};
+
+// ── Injector unit tests ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn latency_injector_activates_and_recovers() {
+    let inj = LatencyInjector::new("test-service", Duration::from_millis(10));
+    assert!(!inj.is_active());
+
+    inj.inject().await.unwrap();
+    assert!(inj.is_active());
+
+    inj.recover().await.unwrap();
+    assert!(!inj.is_active());
+}
+
+#[tokio::test]
+async fn latency_injector_applies_delay_when_active() {
+    let inj = LatencyInjector::new("test-service", Duration::from_millis(50));
+    inj.inject().await.unwrap();
+
+    let start = std::time::Instant::now();
+    inj.maybe_delay().await;
+    assert!(start.elapsed() >= Duration::from_millis(40));
+
+    inj.recover().await.unwrap();
+    let start = std::time::Instant::now();
+    inj.maybe_delay().await;
+    assert!(start.elapsed() < Duration::from_millis(10));
+}
+
+#[tokio::test]
+async fn database_failure_injector_activates_and_recovers() {
+    let inj = DatabaseFailureInjector::new(1.0);
+    inj.inject().await.unwrap();
+
+    // With 100 % failure rate, maybe_fail must always return Err.
+    assert!(inj.maybe_fail().is_err());
+
+    inj.recover().await.unwrap();
+    // After recovery, maybe_fail must always return Ok.
+    assert!(inj.maybe_fail().is_ok());
+}
+
+#[tokio::test]
+async fn database_failure_injector_zero_rate_never_fails() {
+    let inj = DatabaseFailureInjector::new(0.0);
+    inj.inject().await.unwrap();
+    for _ in 0..100 {
+        assert!(inj.maybe_fail().is_ok());
+    }
+}
+
+#[tokio::test]
+async fn network_partition_injector_toggles() {
+    let inj = NetworkPartitionInjector::new("stellar-horizon");
+    assert!(!inj.is_partitioned());
+
+    inj.inject().await.unwrap();
+    assert!(inj.is_partitioned());
+
+    inj.recover().await.unwrap();
+    assert!(!inj.is_partitioned());
+}
+
+#[tokio::test]
+async fn service_crash_injector_toggles() {
+    let inj = ServiceCrashInjector::new("tip-service");
+    assert!(!inj.is_crashed());
+
+    inj.inject().await.unwrap();
+    assert!(inj.is_crashed());
+
+    inj.recover().await.unwrap();
+    assert!(!inj.is_crashed());
+}
+
+// ── Metrics tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn metrics_collector_computes_error_rate() {
+    let mut col = MetricsCollector::new();
+    col.record_success(Duration::from_millis(10));
+    col.record_success(Duration::from_millis(20));
+    col.record_error();
+
+    let m = col.snapshot();
+    assert!((m.error_rate - 1.0 / 3.0).abs() < 0.01);
+    assert_eq!(m.success_count, 2);
+    assert_eq!(m.failure_count, 1);
+}
+
+#[test]
+fn metrics_collector_p99_latency() {
+    let mut col = MetricsCollector::new();
+    for ms in 1u64..=100 {
+        col.record_success(Duration::from_millis(ms));
+    }
+    let m = col.snapshot();
+    // p99 of 1..=100 ms should be close to 99 ms.
+    assert!(m.p99_latency_ms >= 95.0 && m.p99_latency_ms <= 100.0);
+}
+
+#[test]
+fn metrics_collector_empty_snapshot() {
+    let mut col = MetricsCollector::new();
+    let m = col.snapshot();
+    assert_eq!(m.error_rate, 0.0);
+    assert_eq!(m.p99_latency_ms, 0.0);
+}
+
+// ── Experiment evaluation tests ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn experiment_passes_when_thresholds_met() {
+    let experiment = ChaosExperiment::new("test", Duration::from_millis(1))
+        .with_injector(Box::new(LatencyInjector::new("svc", Duration::from_millis(1))))
+        .with_thresholds(ResilienceThresholds {
+            max_error_rate_during_chaos: 0.10,
+            max_latency_multiplier: 10.0,
+            max_recovery_error_rate_multiplier: 2.0,
+        });
+
+    let mut baseline = MetricsCollector::new();
+    let mut chaos = MetricsCollector::new();
+    let mut recovery = MetricsCollector::new();
+
+    // Simulate healthy metrics.
+    baseline.record_success(Duration::from_millis(5));
+    chaos.record_success(Duration::from_millis(8));
+    recovery.record_success(Duration::from_millis(5));
+
+    let result = experiment.run(&mut baseline, &mut chaos, &mut recovery).await.unwrap();
+    assert!(result.passed, "Experiment should pass with healthy metrics");
+}
+
+#[tokio::test]
+async fn experiment_fails_when_error_rate_exceeded() {
+    let experiment = ChaosExperiment::new("test", Duration::from_millis(1))
+        .with_injector(Box::new(DatabaseFailureInjector::new(0.0)))
+        .with_thresholds(ResilienceThresholds {
+            max_error_rate_during_chaos: 0.05,
+            max_latency_multiplier: 2.0,
+            max_recovery_error_rate_multiplier: 1.1,
+        });
+
+    let mut baseline = MetricsCollector::new();
+    let mut chaos = MetricsCollector::new();
+    let mut recovery = MetricsCollector::new();
+
+    // Simulate 50 % error rate during chaos.
+    chaos.record_success(Duration::from_millis(5));
+    chaos.record_error();
+
+    let result = experiment.run(&mut baseline, &mut chaos, &mut recovery).await.unwrap();
+    assert!(!result.passed, "Experiment should fail with high error rate");
+}
+
+// ── Scenario smoke tests ──────────────────────────────────────────────────────
+
+#[test]
+fn scenarios_all_returns_six_experiments() {
+    assert_eq!(ChaosScenarios::all().len(), 6);
+}
+
+#[test]
+fn scenario_names_are_unique() {
+    let names: Vec<_> = ChaosScenarios::all().iter().map(|e| e.name.clone()).collect();
+    let unique: std::collections::HashSet<_> = names.iter().collect();
+    assert_eq!(names.len(), unique.len());
+}
+
+// ── Runner report test ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn runner_generates_report() {
+    let runner = ChaosRunner::new(Duration::from_millis(1));
+
+    let experiment = ChaosExperiment::new("Report Test", Duration::from_millis(1))
+        .with_injector(Box::new(LatencyInjector::new("svc", Duration::from_millis(1))));
+
+    let experiments = vec![(
+        experiment,
+        MetricsCollector::new(),
+        MetricsCollector::new(),
+        MetricsCollector::new(),
+    )];
+
+    let results = runner.run_all(experiments).await.unwrap();
+    let report = runner.generate_report(&results);
+
+    assert!(report.contains("Chaos Engineering Report"));
+    assert!(report.contains("Report Test"));
+    assert_eq!(results.len(), 1);
+}
+
+#[test]
+fn assert_all_passed_panics_on_failure() {
+    use stellar_tipjar_backend::chaos::experiments::ExperimentResult;
+    use stellar_tipjar_backend::chaos::metrics::Metrics;
+
+    let results = vec![ExperimentResult {
+        name: "failing".into(),
+        baseline: Metrics::default(),
+        chaos_metrics: Metrics::default(),
+        recovery_metrics: Metrics::default(),
+        passed: false,
+    }];
+
+    let result = std::panic::catch_unwind(|| assert_all_passed(&results));
+    assert!(result.is_err(), "Should panic when an experiment failed");
+}


### PR DESCRIPTION
This PR 
closes #168 
closes #78 
closes #121 
closes #134 


Issue 1 - Chaos engineering framework:
- src/chaos/mod.rs: ChaosError type and module root
- src/chaos/injectors.rs: LatencyInjector, DatabaseFailureInjector, NetworkPartitionInjector, ServiceCrashInjector (all implement ChaosInjector trait)
- src/chaos/metrics.rs: MetricsCollector, Metrics snapshot, LatencyTimer
- src/chaos/experiments.rs: ChaosExperiment runner, ResilienceThresholds, ChaosRunner with report generation, assert_all_passed helper
- src/chaos/scenarios.rs: pre-built scenarios (database_outage, flakiness, stellar_network_partition, high_database_latency, tip_service_crash, degraded_mode)
- tests/chaos/mod.rs: full test suite covering injectors, metrics, experiment evaluation, scenarios, and report generation

Issue 2 - Transaction handling:
- src/db/transaction.rs: add with_transaction and with_serializable_transaction generic wrappers (commit on Ok, rollback on Err)
- src/db/retry.rs: with_db_retry — deadlock/serialization-aware exponential backoff retry for database operations
- src/services/tip_service.rs: bulk_record_tips now uses with_transaction + with_db_retry instead of manual begin/commit
- src/models/tip.rs: derive Clone on RecordTipRequest (needed for retry closure)

Issues 3 & 4 already fully implemented in the codebase:
- Admin API with X-Admin-Key middleware, audit logging, moderation endpoints
- ValidatedJson extractor with validator crate on all request DTOs

Cargo.toml: comment out invalid tarpaulin dev-dep, fix validator feature flag