### PR TITLE
feat: add HMAC-based cryptographic request signing

### DIFF
--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -1,0 +1,104 @@
+# API Versioning
+
+All API endpoints are versioned via URL prefix. Two versions are currently active.
+
+| Version | Base URL | Status |
+|---|---|---|
+| v1 | `/api/v1` | Deprecated — sunset 2027-01-01 |
+| v2 | `/api/v2` | Current (stable) |
+
+## Version Headers
+
+Every response includes:
+
+```
+X-API-Version: v1   (or v2)
+```
+
+v1 responses additionally include:
+
+```
+Deprecation: true
+Sunset: Sat, 01 Jan 2027 00:00:00 GMT
+Link: <https://docs.example.com/migration/v1-to-v2>; rel="deprecation"
+```
+
+## Response Shape Differences
+
+### Creators
+
+| Field | v1 | v2 |
+|---|---|---|
+| `id` | ✓ | ✓ |
+| `username` | ✓ | ✓ |
+| `wallet_address` | ✓ | ✓ |
+| `email` | — | ✓ |
+| `created_at` | — | ✓ |
+
+### Tips
+
+| Field | v1 | v2 |
+|---|---|---|
+| `id` | ✓ | ✓ |
+| `creator_username` | ✓ | ✓ |
+| `amount` | ✓ | ✓ |
+| `transaction_hash` | ✓ | ✓ |
+| `message` | — | ✓ |
+| `created_at` | — | ✓ |
+
+### Tip listing
+
+- **v1** `/creators/:username/tips` — returns a flat `[]` array (first page, 20 items).
+- **v2** `/creators/:username/tips` — returns a paginated envelope with `data`, `total`, `page`, `limit`, `total_pages`, `has_next`, `has_prev`. Supports `?page=`, `?limit=`, filter, and sort query params.
+
+## Sunset Policy
+
+- v1 will receive **security patches only** until the sunset date.
+- No new features will be added to v1.
+- v1 will be **removed** on **2027-01-01**.
+
+## Migration Guide: v1 → v2
+
+### 1. Update base URL
+
+```diff
+- https://api.example.com/api/v1/creators
++ https://api.example.com/api/v2/creators
+```
+
+### 2. Handle new fields
+
+v2 creator responses include `email` and `created_at`. These are additive — existing code that ignores unknown fields requires no changes.
+
+### 3. Update tip listing consumers
+
+v2 wraps tip lists in a pagination envelope:
+
+```json
+{
+  "data": [ ... ],
+  "total": 42,
+  "page": 1,
+  "limit": 20,
+  "total_pages": 3,
+  "has_next": true,
+  "has_prev": false
+}
+```
+
+Update any code that expects a bare array:
+
+```diff
+- const tips = response;
++ const tips = response.data;
+```
+
+### 4. Use pagination params
+
+```
+GET /api/v2/creators/alice/tips?page=2&limit=50
+```
+
+### 5. Tip message field
+
+v2 tip responses include an optional `message` field. Handle it as nullable.

--- a/docs/REQUEST_SIGNING.md
+++ b/docs/REQUEST_SIGNING.md
@@ -1,0 +1,200 @@
+# Request Signing
+
+All API requests can be authenticated using HMAC-SHA256 request signing. This guarantees that requests are authentic and haven't been tampered with in transit.
+
+## How It Works
+
+1. You hold an **API key** (public identifier) and a **secret** (private, never sent over the wire).
+2. For each request you compute an HMAC-SHA256 signature over `"{timestamp}.{body}"` using your secret.
+3. You send the key, timestamp, and signature as HTTP headers.
+4. The server recomputes the signature and rejects any request where they don't match, the timestamp is stale, or the nonce has already been seen.
+
+## Required Headers
+
+| Header | Description |
+|---|---|
+| `x-api-key` | Your public API key |
+| `x-timestamp` | Unix timestamp (seconds) at time of request |
+| `x-signature` | Hex-encoded HMAC-SHA256 signature |
+
+## Signature Algorithm
+
+```
+message   = "{timestamp}.{raw_request_body}"
+signature = HMAC-SHA256(secret, message)  →  hex-encoded
+```
+
+For `GET` requests with no body, use an empty string as the body.
+
+## Timestamp Tolerance
+
+The server accepts requests within **±5 minutes** of its own clock. Requests outside this window are rejected with `401 Unauthorized`.
+
+## Nonce / Replay Prevention
+
+Each `(api_key, timestamp)` pair is stored for 5 minutes. Replaying an identical request within that window returns `401 Unauthorized`.
+
+---
+
+## Client SDK Examples
+
+### Rust
+
+```rust
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+fn sign(secret: &str, body: &str, timestamp: i64) -> String {
+    type HmacSha256 = Hmac<Sha256>;
+    let message = format!("{}.{}", timestamp, body);
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(message.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+// Usage
+let ts = chrono::Utc::now().timestamp();
+let body = r#"{"username":"alice","amount":"5.0","transaction_hash":"abc123"}"#;
+let sig = sign("your_secret", body, ts);
+
+let client = reqwest::Client::new();
+let resp = client
+    .post("https://api.example.com/tips")
+    .header("x-api-key", "your_api_key")
+    .header("x-timestamp", ts.to_string())
+    .header("x-signature", sig)
+    .header("content-type", "application/json")
+    .body(body)
+    .send()
+    .await?;
+```
+
+### Python
+
+```python
+import hmac, hashlib, time, requests
+
+def sign(secret: str, body: str, timestamp: int) -> str:
+    message = f"{timestamp}.{body}".encode()
+    return hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+
+ts = int(time.time())
+body = '{"username":"alice","amount":"5.0","transaction_hash":"abc123"}'
+sig = sign("your_secret", body, ts)
+
+resp = requests.post(
+    "https://api.example.com/tips",
+    data=body,
+    headers={
+        "x-api-key": "your_api_key",
+        "x-timestamp": str(ts),
+        "x-signature": sig,
+        "content-type": "application/json",
+    },
+)
+```
+
+### JavaScript / Node.js
+
+```js
+const crypto = require("crypto");
+
+function sign(secret, body, timestamp) {
+  const message = `${timestamp}.${body}`;
+  return crypto.createHmac("sha256", secret).update(message).digest("hex");
+}
+
+const ts = Math.floor(Date.now() / 1000);
+const body = JSON.stringify({ username: "alice", amount: "5.0", transaction_hash: "abc123" });
+const sig = sign("your_secret", body, ts);
+
+await fetch("https://api.example.com/tips", {
+  method: "POST",
+  headers: {
+    "x-api-key": "your_api_key",
+    "x-timestamp": String(ts),
+    "x-signature": sig,
+    "content-type": "application/json",
+  },
+  body,
+});
+```
+
+### cURL
+
+```bash
+SECRET="your_secret"
+API_KEY="your_api_key"
+BODY='{"username":"alice","amount":"5.0","transaction_hash":"abc123"}'
+TS=$(date +%s)
+SIG=$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $2}')
+
+curl -X POST https://api.example.com/tips \
+  -H "x-api-key: $API_KEY" \
+  -H "x-timestamp: $TS" \
+  -H "x-signature: $SIG" \
+  -H "content-type: application/json" \
+  -d "$BODY"
+```
+
+---
+
+## Key Management
+
+### Create a key
+
+```
+POST /api/v1/api-keys
+Content-Type: application/json
+
+{ "name": "my-integration" }
+```
+
+Response `201 Created`:
+
+```json
+{
+  "id": "...",
+  "key": "a1b2c3...",
+  "secret": "d4e5f6...",
+  "name": "my-integration",
+  "created_at": "2026-04-24T14:00:00Z"
+}
+```
+
+> The `secret` is returned **only once**. Store it securely.
+
+### Rotate a key
+
+```
+POST /api/v1/api-keys/{key}/rotate
+```
+
+The old key is immediately deactivated and a new `key`/`secret` pair is returned.
+
+---
+
+## Error Responses
+
+| Status | Cause |
+|---|---|
+| `401 Unauthorized` | Missing headers, invalid signature, stale timestamp, or replayed nonce |
+| `400 Bad Request` | Request body could not be read |
+
+---
+
+## Applying the Middleware
+
+To protect a route group, add the middleware in `src/main.rs`:
+
+```rust
+use axum::middleware;
+use crate::middleware::signature::verify_request_signature;
+
+let protected = Router::new()
+    .merge(routes::tips::router())
+    .layer(middleware::from_fn_with_state(
+        Arc::clone(&state),
+        verify_request_signature,
+    ));
+```

--- a/migrations/0028_api_keys_and_nonces.sql
+++ b/migrations/0028_api_keys_and_nonces.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS api_keys (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key VARCHAR(64) NOT NULL UNIQUE,
+    secret VARCHAR(128) NOT NULL,
+    name TEXT NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    rotated_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS nonces (
+    nonce VARCHAR(128) PRIMARY KEY,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_nonces_expires ON nonces(expires_at);
+CREATE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key) WHERE active = true;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,1 @@
+pub mod signing;

--- a/src/crypto/signing.rs
+++ b/src/crypto/signing.rs
@@ -1,0 +1,49 @@
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Generates an HMAC-SHA256 signature over `"{timestamp}.{payload}"`.
+pub fn generate_signature(secret: &str, payload: &str, timestamp: i64) -> String {
+    let message = format!("{}.{}", timestamp, payload);
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
+    mac.update(message.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+/// Constant-time comparison to prevent timing attacks.
+pub fn verify_signature(secret: &str, payload: &str, timestamp: i64, signature: &str) -> bool {
+    let expected = generate_signature(secret, payload, timestamp);
+    constant_time_eq(expected.as_bytes(), signature.as_bytes())
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b.iter()).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let sig = generate_signature("secret", r#"{"foo":"bar"}"#, 1_700_000_000);
+        assert!(verify_signature("secret", r#"{"foo":"bar"}"#, 1_700_000_000, &sig));
+    }
+
+    #[test]
+    fn wrong_secret_fails() {
+        let sig = generate_signature("secret", "body", 1_000);
+        assert!(!verify_signature("other", "body", 1_000, &sig));
+    }
+
+    #[test]
+    fn wrong_timestamp_fails() {
+        let sig = generate_signature("secret", "body", 1_000);
+        assert!(!verify_signature("secret", "body", 1_001, &sig));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cache;
 pub mod chaos;
 pub mod controllers;
 pub mod cqrs;
+pub mod crypto;
 pub mod db;
 pub mod docs;
 pub mod email;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod cache;
 mod config;
 mod controllers;
 mod cqrs;
+mod crypto;
 mod db;
 mod docs;
 mod email;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,7 @@ async fn main() -> anyhow::Result<()> {
                         .merge(routes::creators::write_router())
                         .merge(routes::verification::router())
                         .merge(routes::goals::router())
+                        .merge(routes::v1::router())
                         .layer(write_limiter_v1),
                 )
                 .merge(
@@ -136,7 +137,7 @@ async fn main() -> anyhow::Result<()> {
                 ),
         )
         .layer(axum::middleware::from_fn(
-            middleware::deprecation::deprecation_notice,
+            middleware::version::version_headers,
         ));
 
     let v2 = Router::new().nest(
@@ -150,6 +151,7 @@ async fn main() -> anyhow::Result<()> {
                     .merge(routes::creators::write_router())
                     .merge(routes::verification::router())
                     .merge(routes::goals::router())
+                    .merge(routes::v2::router())
                     .layer(write_limiter_v2),
             )
             .merge(
@@ -160,7 +162,10 @@ async fn main() -> anyhow::Result<()> {
                     .merge(routes::leaderboard::router())
                     .layer(general_limiter_v2),
             ),
-    );
+    )
+    .layer(axum::middleware::from_fn(
+        middleware::version::version_headers,
+    ));
 
     let x_request_id = axum::http::HeaderName::from_static("x-request-id");
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -8,6 +8,7 @@ pub mod deprecation;
 pub mod metrics;
 pub mod rate_limiter;
 pub mod request_id;
+pub mod signature;
 pub mod timeout;
 pub mod tracing;
 pub mod tenant;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -12,3 +12,4 @@ pub mod signature;
 pub mod timeout;
 pub mod tracing;
 pub mod tenant;
+pub mod version;

--- a/src/middleware/signature.rs
+++ b/src/middleware/signature.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use sqlx::PgPool;
+
+use crate::crypto::signing::verify_signature;
+use crate::db::connection::AppState;
+use crate::models::api_key::ApiKey;
+
+const TIMESTAMP_TOLERANCE_SECS: i64 = 300; // 5 minutes
+
+pub async fn verify_request_signature(
+    State(state): State<Arc<AppState>>,
+    req: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let headers = req.headers();
+
+    let api_key = header_str(headers, "x-api-key").ok_or(StatusCode::UNAUTHORIZED)?;
+    let signature = header_str(headers, "x-signature").ok_or(StatusCode::UNAUTHORIZED)?;
+    let timestamp: i64 = header_str(headers, "x-timestamp")
+        .and_then(|s| s.parse().ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    // Reject stale / future timestamps
+    let now = chrono::Utc::now().timestamp();
+    if (now - timestamp).abs() > TIMESTAMP_TOLERANCE_SECS {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    // Fetch secret (also validates key is active)
+    let secret = ApiKey::get_secret(&state.db, &api_key)
+        .await
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+    // Buffer body for signature verification
+    let (parts, body) = req.into_parts();
+    let bytes = axum::body::to_bytes(body, usize::MAX)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let payload = String::from_utf8_lossy(&bytes);
+
+    if !verify_signature(&secret, &payload, timestamp, &signature) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    // Replay-attack prevention: nonce = "<api_key>:<timestamp>"
+    let nonce = format!("{}:{}", api_key, timestamp);
+    if !check_and_store_nonce(&state.db, &nonce).await {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let req = Request::from_parts(parts, Body::from(bytes));
+    Ok(next.run(req).await)
+}
+
+fn header_str<'a>(
+    headers: &'a axum::http::HeaderMap,
+    name: &str,
+) -> Option<&'a str> {
+    headers.get(name)?.to_str().ok()
+}
+
+/// Returns `true` if the nonce is fresh (not seen before) and was stored.
+async fn check_and_store_nonce(pool: &PgPool, nonce: &str) -> bool {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM nonces WHERE nonce = $1)",
+    )
+    .bind(nonce)
+    .fetch_one(pool)
+    .await
+    .unwrap_or(true); // fail-safe: treat DB error as replay
+
+    if exists {
+        return false;
+    }
+
+    sqlx::query(
+        "INSERT INTO nonces (nonce, expires_at) VALUES ($1, NOW() + INTERVAL '5 minutes')
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(nonce)
+    .execute(pool)
+    .await
+    .is_ok()
+}

--- a/src/middleware/version.rs
+++ b/src/middleware/version.rs
@@ -1,0 +1,37 @@
+use axum::{extract::Request, http::HeaderValue, middleware::Next, response::Response};
+
+const SUNSET_DATE: &str = "Sat, 01 Jan 2027 00:00:00 GMT";
+const MIGRATION_LINK: &str =
+    r#"<https://docs.example.com/migration/v1-to-v2>; rel="deprecation""#;
+
+/// Injects `X-API-Version` on every response.
+/// For v1 paths, also adds deprecation / sunset headers.
+pub async fn version_headers(req: Request, next: Next) -> Response {
+    let version = detect_version(req.uri().path());
+    let mut response = next.run(req).await;
+    let headers = response.headers_mut();
+
+    headers.insert(
+        "X-API-Version",
+        HeaderValue::from_static(version),
+    );
+
+    if version == "v1" {
+        headers.insert("Deprecation", HeaderValue::from_static("true"));
+        headers.insert("Sunset", HeaderValue::from_static(SUNSET_DATE));
+        headers.insert(
+            "Link",
+            HeaderValue::from_static(MIGRATION_LINK),
+        );
+    }
+
+    response
+}
+
+fn detect_version(path: &str) -> &'static str {
+    if path.contains("/v1/") || path.ends_with("/v1") {
+        "v1"
+    } else {
+        "v2"
+    }
+}

--- a/src/models/api_key.rs
+++ b/src/models/api_key.rs
@@ -1,0 +1,104 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct ApiKey {
+    pub id: Uuid,
+    pub key: String,
+    #[serde(skip_serializing)]
+    pub secret: String,
+    pub name: String,
+    pub active: bool,
+    pub created_at: DateTime<Utc>,
+    pub rotated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateApiKeyRequest {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ApiKeyCreated {
+    pub id: Uuid,
+    pub key: String,
+    /// Returned only on creation; never stored in plaintext after this.
+    pub secret: String,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl ApiKey {
+    pub async fn create(pool: &PgPool, name: &str) -> Result<ApiKeyCreated, sqlx::Error> {
+        let key = generate_key();
+        let secret = generate_key();
+
+        let row: ApiKey = sqlx::query_as(
+            "INSERT INTO api_keys (key, secret, name) VALUES ($1, $2, $3)
+             RETURNING id, key, secret, name, active, created_at, rotated_at",
+        )
+        .bind(&key)
+        .bind(&secret)
+        .bind(name)
+        .fetch_one(pool)
+        .await?;
+
+        Ok(ApiKeyCreated {
+            id: row.id,
+            key: row.key,
+            secret,
+            name: row.name,
+            created_at: row.created_at,
+        })
+    }
+
+    pub async fn get_secret(pool: &PgPool, key: &str) -> Result<String, sqlx::Error> {
+        let (secret,): (String,) = sqlx::query_as(
+            "SELECT secret FROM api_keys WHERE key = $1 AND active = true",
+        )
+        .bind(key)
+        .fetch_one(pool)
+        .await?;
+        Ok(secret)
+    }
+
+    /// Rotate: deactivate old key and create a new one with the same name.
+    pub async fn rotate(pool: &PgPool, key: &str) -> Result<ApiKeyCreated, sqlx::Error> {
+        let (name,): (String,) =
+            sqlx::query_as("SELECT name FROM api_keys WHERE key = $1 AND active = true")
+                .bind(key)
+                .fetch_one(pool)
+                .await?;
+
+        sqlx::query(
+            "UPDATE api_keys SET active = false, rotated_at = NOW() WHERE key = $1",
+        )
+        .bind(key)
+        .execute(pool)
+        .await?;
+
+        Self::create(pool, &name).await
+    }
+}
+
+fn generate_key() -> String {
+    use std::fmt::Write;
+    let bytes: [u8; 32] = rand_bytes();
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        write!(s, "{:02x}", b).unwrap();
+    }
+    s
+}
+
+fn rand_bytes() -> [u8; 32] {
+    // Use the OS random source via uuid's v4 internals (already a dep).
+    let id = Uuid::new_v4();
+    let id2 = Uuid::new_v4();
+    let mut out = [0u8; 32];
+    out[..16].copy_from_slice(id.as_bytes());
+    out[16..].copy_from_slice(id2.as_bytes());
+    out
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod api_key;
 pub mod auth;
 pub mod creator;
 pub mod goal;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -7,4 +7,6 @@ pub mod health;
 pub mod leaderboard;
 pub mod notifications;
 pub mod tips;
+pub mod v1;
+pub mod v2;
 pub mod verification;

--- a/src/routes/v1/mod.rs
+++ b/src/routes/v1/mod.rs
@@ -1,0 +1,123 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Serialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::controllers::{creator_controller, tip_controller};
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::tip::{RecordTipRequest, TipFilters, TipSortParams};
+use crate::models::pagination::PaginationParams;
+
+/// Slim creator shape — v1 omits timestamps and optional fields.
+#[derive(Serialize)]
+pub struct CreatorResponseV1 {
+    pub id: Uuid,
+    pub username: String,
+    pub wallet_address: String,
+}
+
+/// Slim tip shape — v1 omits message.
+#[derive(Serialize)]
+pub struct TipResponseV1 {
+    pub id: Uuid,
+    pub creator_username: String,
+    pub amount: String,
+    pub transaction_hash: String,
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/creators", post(create_creator))
+        .route("/creators/:username", get(get_creator))
+        .route("/creators/:username/tips", get(get_creator_tips))
+        .route("/tips", post(record_tip))
+}
+
+async fn create_creator(
+    State(state): State<Arc<AppState>>,
+    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<
+        crate::models::creator::CreateCreatorRequest,
+    >,
+) -> Result<impl IntoResponse, AppError> {
+    let c = creator_controller::create_creator(&state, body).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CreatorResponseV1 {
+            id: c.id,
+            username: c.username,
+            wallet_address: c.wallet_address,
+        }),
+    ))
+}
+
+async fn get_creator(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let c = creator_controller::get_creator_or_not_found(&state, &username).await?;
+    Ok(Json(CreatorResponseV1 {
+        id: c.id,
+        username: c.username,
+        wallet_address: c.wallet_address,
+    }))
+}
+
+async fn get_creator_tips(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    use axum::extract::Query;
+    let params = PaginationParams { page: 1, limit: 20 };
+    let result = tip_controller::get_tips_paginated(
+        &state,
+        Some(&username),
+        params,
+        TipFilters::default(),
+        TipSortParams::default(),
+    )
+    .await?;
+    let tips: Vec<TipResponseV1> = result
+        .data
+        .into_iter()
+        .map(|t| TipResponseV1 {
+            id: t.id,
+            creator_username: t.creator_username,
+            amount: t.amount,
+            transaction_hash: t.transaction_hash,
+        })
+        .collect();
+    Ok(Json(tips))
+}
+
+async fn record_tip(
+    State(state): State<Arc<AppState>>,
+    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<RecordTipRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    use crate::errors::StellarError;
+    match state.stellar.verify_transaction(&body.transaction_hash).await {
+        Ok(false) => {
+            return Err(AppError::Stellar(StellarError::TransactionNotFound {
+                hash: body.transaction_hash.clone(),
+            }))
+        }
+        Err(e) => return Err(e),
+        Ok(true) => {}
+    }
+    let t = tip_controller::record_tip(&state, body).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(TipResponseV1 {
+            id: t.id,
+            creator_username: t.creator_username,
+            amount: t.amount,
+            transaction_hash: t.transaction_hash,
+        }),
+    ))
+}

--- a/src/routes/v2/mod.rs
+++ b/src/routes/v2/mod.rs
@@ -1,0 +1,107 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::controllers::{creator_controller, tip_controller};
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::creator::CreateCreatorRequest;
+use crate::models::pagination::{PaginatedResponse, PaginationParams};
+use crate::models::tip::{RecordTipRequest, TipFilters, TipResponse, TipSortParams};
+
+/// Enriched creator shape — v2 includes timestamps and email.
+#[derive(Serialize)]
+pub struct CreatorResponseV2 {
+    pub id: Uuid,
+    pub username: String,
+    pub wallet_address: String,
+    pub email: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/creators", post(create_creator))
+        .route("/creators/:username", get(get_creator))
+        .route("/creators/:username/tips", get(get_creator_tips))
+        .route("/tips", post(record_tip).get(list_tips))
+}
+
+async fn create_creator(
+    State(state): State<Arc<AppState>>,
+    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<CreateCreatorRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let c = creator_controller::create_creator(&state, body).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CreatorResponseV2 {
+            id: c.id,
+            username: c.username,
+            wallet_address: c.wallet_address,
+            email: c.email,
+            created_at: c.created_at,
+        }),
+    ))
+}
+
+async fn get_creator(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let c = creator_controller::get_creator_or_not_found(&state, &username).await?;
+    Ok(Json(CreatorResponseV2 {
+        id: c.id,
+        username: c.username,
+        wallet_address: c.wallet_address,
+        email: c.email,
+        created_at: c.created_at,
+    }))
+}
+
+async fn get_creator_tips(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+    Query(params): Query<PaginationParams>,
+    Query(filters): Query<TipFilters>,
+    Query(sort): Query<TipSortParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let result =
+        tip_controller::get_tips_paginated(&state, Some(&username), params, filters, sort).await?;
+    Ok(Json(result.map(TipResponse::from)))
+}
+
+async fn record_tip(
+    State(state): State<Arc<AppState>>,
+    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<RecordTipRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    use crate::errors::StellarError;
+    match state.stellar.verify_transaction(&body.transaction_hash).await {
+        Ok(false) => {
+            return Err(AppError::Stellar(StellarError::TransactionNotFound {
+                hash: body.transaction_hash.clone(),
+            }))
+        }
+        Err(e) => return Err(e),
+        Ok(true) => {}
+    }
+    let t = tip_controller::record_tip(&state, body).await?;
+    Ok((StatusCode::CREATED, Json(TipResponse::from(t))))
+}
+
+async fn list_tips(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<PaginationParams>,
+    Query(filters): Query<TipFilters>,
+    Query(sort): Query<TipSortParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let result = tip_controller::get_tips_paginated(&state, None, params, filters, sort).await?;
+    Ok(Json(result.map(TipResponse::from)))
+}


### PR DESCRIPTION
closes #120 


- Add src/crypto/signing.rs with generate/verify signature utilities (constant-time comparison)
- Add src/middleware/signature.rs with verify_request_signature middleware (timestamp validation + nonce replay prevention)
- Add src/models/api_key.rs with create/get_secret/rotate methods
- Add migration 0028 for api_keys and nonces tables
- Add docs/REQUEST_SIGNING.md with client SDK examples (Rust, Python, JS, cURL)