### PR TITLE
feat(api): implement API versioning strategy

### DIFF
--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -1,0 +1,104 @@
+# API Versioning
+
+All API endpoints are versioned via URL prefix. Two versions are currently active.
+
+| Version | Base URL | Status |
+|---|---|---|
+| v1 | `/api/v1` | Deprecated — sunset 2027-01-01 |
+| v2 | `/api/v2` | Current (stable) |
+
+## Version Headers
+
+Every response includes:
+
+```
+X-API-Version: v1   (or v2)
+```
+
+v1 responses additionally include:
+
+```
+Deprecation: true
+Sunset: Sat, 01 Jan 2027 00:00:00 GMT
+Link: <https://docs.example.com/migration/v1-to-v2>; rel="deprecation"
+```
+
+## Response Shape Differences
+
+### Creators
+
+| Field | v1 | v2 |
+|---|---|---|
+| `id` | ✓ | ✓ |
+| `username` | ✓ | ✓ |
+| `wallet_address` | ✓ | ✓ |
+| `email` | — | ✓ |
+| `created_at` | — | ✓ |
+
+### Tips
+
+| Field | v1 | v2 |
+|---|---|---|
+| `id` | ✓ | ✓ |
+| `creator_username` | ✓ | ✓ |
+| `amount` | ✓ | ✓ |
+| `transaction_hash` | ✓ | ✓ |
+| `message` | — | ✓ |
+| `created_at` | — | ✓ |
+
+### Tip listing
+
+- **v1** `/creators/:username/tips` — returns a flat `[]` array (first page, 20 items).
+- **v2** `/creators/:username/tips` — returns a paginated envelope with `data`, `total`, `page`, `limit`, `total_pages`, `has_next`, `has_prev`. Supports `?page=`, `?limit=`, filter, and sort query params.
+
+## Sunset Policy
+
+- v1 will receive **security patches only** until the sunset date.
+- No new features will be added to v1.
+- v1 will be **removed** on **2027-01-01**.
+
+## Migration Guide: v1 → v2
+
+### 1. Update base URL
+
+```diff
+- https://api.example.com/api/v1/creators
++ https://api.example.com/api/v2/creators
+```
+
+### 2. Handle new fields
+
+v2 creator responses include `email` and `created_at`. These are additive — existing code that ignores unknown fields requires no changes.
+
+### 3. Update tip listing consumers
+
+v2 wraps tip lists in a pagination envelope:
+
+```json
+{
+  "data": [ ... ],
+  "total": 42,
+  "page": 1,
+  "limit": 20,
+  "total_pages": 3,
+  "has_next": true,
+  "has_prev": false
+}
+```
+
+Update any code that expects a bare array:
+
+```diff
+- const tips = response;
++ const tips = response.data;
+```
+
+### 4. Use pagination params
+
+```
+GET /api/v2/creators/alice/tips?page=2&limit=50
+```
+
+### 5. Tip message field
+
+v2 tip responses include an optional `message` field. Handle it as nullable.

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,7 @@ async fn main() -> anyhow::Result<()> {
                         .merge(routes::creators::write_router())
                         .merge(routes::verification::router())
                         .merge(routes::goals::router())
+                        .merge(routes::v1::router())
                         .layer(write_limiter_v1),
                 )
                 .merge(
@@ -135,7 +136,7 @@ async fn main() -> anyhow::Result<()> {
                 ),
         )
         .layer(axum::middleware::from_fn(
-            middleware::deprecation::deprecation_notice,
+            middleware::version::version_headers,
         ));
 
     let v2 = Router::new().nest(
@@ -149,6 +150,7 @@ async fn main() -> anyhow::Result<()> {
                     .merge(routes::creators::write_router())
                     .merge(routes::verification::router())
                     .merge(routes::goals::router())
+                    .merge(routes::v2::router())
                     .layer(write_limiter_v2),
             )
             .merge(
@@ -159,7 +161,10 @@ async fn main() -> anyhow::Result<()> {
                     .merge(routes::leaderboard::router())
                     .layer(general_limiter_v2),
             ),
-    );
+    )
+    .layer(axum::middleware::from_fn(
+        middleware::version::version_headers,
+    ));
 
     let x_request_id = axum::http::HeaderName::from_static("x-request-id");
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -11,3 +11,4 @@ pub mod request_id;
 pub mod timeout;
 pub mod tracing;
 pub mod tenant;
+pub mod version;

--- a/src/middleware/version.rs
+++ b/src/middleware/version.rs
@@ -1,0 +1,37 @@
+use axum::{extract::Request, http::HeaderValue, middleware::Next, response::Response};
+
+const SUNSET_DATE: &str = "Sat, 01 Jan 2027 00:00:00 GMT";
+const MIGRATION_LINK: &str =
+    r#"<https://docs.example.com/migration/v1-to-v2>; rel="deprecation""#;
+
+/// Injects `X-API-Version` on every response.
+/// For v1 paths, also adds deprecation / sunset headers.
+pub async fn version_headers(req: Request, next: Next) -> Response {
+    let version = detect_version(req.uri().path());
+    let mut response = next.run(req).await;
+    let headers = response.headers_mut();
+
+    headers.insert(
+        "X-API-Version",
+        HeaderValue::from_static(version),
+    );
+
+    if version == "v1" {
+        headers.insert("Deprecation", HeaderValue::from_static("true"));
+        headers.insert("Sunset", HeaderValue::from_static(SUNSET_DATE));
+        headers.insert(
+            "Link",
+            HeaderValue::from_static(MIGRATION_LINK),
+        );
+    }
+
+    response
+}
+
+fn detect_version(path: &str) -> &'static str {
+    if path.contains("/v1/") || path.ends_with("/v1") {
+        "v1"
+    } else {
+        "v2"
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -7,4 +7,6 @@ pub mod health;
 pub mod leaderboard;
 pub mod notifications;
 pub mod tips;
+pub mod v1;
+pub mod v2;
 pub mod verification;

--- a/src/routes/v1/mod.rs
+++ b/src/routes/v1/mod.rs
@@ -1,0 +1,123 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Serialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::controllers::{creator_controller, tip_controller};
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::tip::{RecordTipRequest, TipFilters, TipSortParams};
+use crate::models::pagination::PaginationParams;
+
+/// Slim creator shape — v1 omits timestamps and optional fields.
+#[derive(Serialize)]
+pub struct CreatorResponseV1 {
+    pub id: Uuid,
+    pub username: String,
+    pub wallet_address: String,
+}
+
+/// Slim tip shape — v1 omits message.
+#[derive(Serialize)]
+pub struct TipResponseV1 {
+    pub id: Uuid,
+    pub creator_username: String,
+    pub amount: String,
+    pub transaction_hash: String,
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/creators", post(create_creator))
+        .route("/creators/:username", get(get_creator))
+        .route("/creators/:username/tips", get(get_creator_tips))
+        .route("/tips", post(record_tip))
+}
+
+async fn create_creator(
+    State(state): State<Arc<AppState>>,
+    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<
+        crate::models::creator::CreateCreatorRequest,
+    >,
+) -> Result<impl IntoResponse, AppError> {
+    let c = creator_controller::create_creator(&state, body).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CreatorResponseV1 {
+            id: c.id,
+            username: c.username,
+            wallet_address: c.wallet_address,
+        }),
+    ))
+}
+
+async fn get_creator(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let c = creator_controller::get_creator_or_not_found(&state, &username).await?;
+    Ok(Json(CreatorResponseV1 {
+        id: c.id,
+        username: c.username,
+        wallet_address: c.wallet_address,
+    }))
+}
+
+async fn get_creator_tips(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    use axum::extract::Query;
+    let params = PaginationParams { page: 1, limit: 20 };
+    let result = tip_controller::get_tips_paginated(
+        &state,
+        Some(&username),
+        params,
+        TipFilters::default(),
+        TipSortParams::default(),
+    )
+    .await?;
+    let tips: Vec<TipResponseV1> = result
+        .data
+        .into_iter()
+        .map(|t| TipResponseV1 {
+            id: t.id,
+            creator_username: t.creator_username,
+            amount: t.amount,
+            transaction_hash: t.transaction_hash,
+        })
+        .collect();
+    Ok(Json(tips))
+}
+
+async fn record_tip(
+    State(state): State<Arc<AppState>>,
+    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<RecordTipRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    use crate::errors::StellarError;
+    match state.stellar.verify_transaction(&body.transaction_hash).await {
+        Ok(false) => {
+            return Err(AppError::Stellar(StellarError::TransactionNotFound {
+                hash: body.transaction_hash.clone(),
+            }))
+        }
+        Err(e) => return Err(e),
+        Ok(true) => {}
+    }
+    let t = tip_controller::record_tip(&state, body).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(TipResponseV1 {
+            id: t.id,
+            creator_username: t.creator_username,
+            amount: t.amount,
+            transaction_hash: t.transaction_hash,
+        }),
+    ))
+}

--- a/src/routes/v2/mod.rs
+++ b/src/routes/v2/mod.rs
@@ -1,0 +1,107 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::controllers::{creator_controller, tip_controller};
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::creator::CreateCreatorRequest;
+use crate::models::pagination::{PaginatedResponse, PaginationParams};
+use crate::models::tip::{RecordTipRequest, TipFilters, TipResponse, TipSortParams};
+
+/// Enriched creator shape — v2 includes timestamps and email.
+#[derive(Serialize)]
+pub struct CreatorResponseV2 {
+    pub id: Uuid,
+    pub username: String,
+    pub wallet_address: String,
+    pub email: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/creators", post(create_creator))
+        .route("/creators/:username", get(get_creator))
+        .route("/creators/:username/tips", get(get_creator_tips))
+        .route("/tips", post(record_tip).get(list_tips))
+}
+
+async fn create_creator(
+    State(state): State<Arc<AppState>>,
+    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<CreateCreatorRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let c = creator_controller::create_creator(&state, body).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CreatorResponseV2 {
+            id: c.id,
+            username: c.username,
+            wallet_address: c.wallet_address,
+            email: c.email,
+            created_at: c.created_at,
+        }),
+    ))
+}
+
+async fn get_creator(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let c = creator_controller::get_creator_or_not_found(&state, &username).await?;
+    Ok(Json(CreatorResponseV2 {
+        id: c.id,
+        username: c.username,
+        wallet_address: c.wallet_address,
+        email: c.email,
+        created_at: c.created_at,
+    }))
+}
+
+async fn get_creator_tips(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+    Query(params): Query<PaginationParams>,
+    Query(filters): Query<TipFilters>,
+    Query(sort): Query<TipSortParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let result =
+        tip_controller::get_tips_paginated(&state, Some(&username), params, filters, sort).await?;
+    Ok(Json(result.map(TipResponse::from)))
+}
+
+async fn record_tip(
+    State(state): State<Arc<AppState>>,
+    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<RecordTipRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    use crate::errors::StellarError;
+    match state.stellar.verify_transaction(&body.transaction_hash).await {
+        Ok(false) => {
+            return Err(AppError::Stellar(StellarError::TransactionNotFound {
+                hash: body.transaction_hash.clone(),
+            }))
+        }
+        Err(e) => return Err(e),
+        Ok(true) => {}
+    }
+    let t = tip_controller::record_tip(&state, body).await?;
+    Ok((StatusCode::CREATED, Json(TipResponse::from(t))))
+}
+
+async fn list_tips(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<PaginationParams>,
+    Query(filters): Query<TipFilters>,
+    Query(sort): Query<TipSortParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let result = tip_controller::get_tips_paginated(&state, None, params, filters, sort).await?;
+    Ok(Json(result.map(TipResponse::from)))
+}


### PR DESCRIPTION
closes #122 
closes #123 
closes #124 

- Add src/middleware/version.rs: injects X-API-Version on all responses, Deprecation/Sunset/Link headers on v1
- Add src/routes/v1/mod.rs: slim CreatorResponseV1 (id/username/wallet) and TipResponseV1 (no timestamps/message)
- Add src/routes/v2/mod.rs: enriched CreatorResponseV2 (+ email/created_at), paginated tip responses with full filter/sort support
- Wire version_headers middleware into both v1 and v2 routers in main.rs
- Add docs/API_VERSIONING.md: response shape diffs, sunset policy, v1→v2 migration guide