### PR TITLE
feat: implement API key management

### DIFF
--- a/migrations/0029_api_keys_permissions_usage.sql
+++ b/migrations/0029_api_keys_permissions_usage.sql
@@ -1,0 +1,8 @@
+ALTER TABLE api_keys
+    ADD COLUMN IF NOT EXISTS permissions TEXT[] NOT NULL DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS usage_count  BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS revoked_at   TIMESTAMPTZ;
+
+-- partial index: only active, non-revoked keys
+CREATE INDEX IF NOT EXISTS idx_api_keys_active ON api_keys(key)
+    WHERE active = true AND revoked_at IS NULL;

--- a/src/controllers/api_key_controller.rs
+++ b/src/controllers/api_key_controller.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::api_key::{ApiKey, ApiKeyCreated, ApiKeyView, CreateApiKeyRequest};
+
+pub async fn create_api_key(
+    state: &Arc<AppState>,
+    req: CreateApiKeyRequest,
+) -> Result<ApiKeyCreated, AppError> {
+    ApiKey::create(&state.db, &req.name, &req.permissions)
+        .await
+        .map_err(AppError::from)
+}
+
+pub async fn list_api_keys(state: &Arc<AppState>) -> Result<Vec<ApiKeyView>, AppError> {
+    let keys = ApiKey::list(&state.db).await.map_err(AppError::from)?;
+    Ok(keys.into_iter().map(ApiKeyView::from).collect())
+}
+
+pub async fn get_api_key(state: &Arc<AppState>, key: &str) -> Result<ApiKeyView, AppError> {
+    ApiKey::get_by_key(&state.db, key)
+        .await
+        .map(ApiKeyView::from)
+        .map_err(|e| match e {
+            sqlx::Error::RowNotFound => AppError::unauthorized("API key not found"),
+            other => AppError::from(other),
+        })
+}
+
+pub async fn rotate_api_key(
+    state: &Arc<AppState>,
+    key: &str,
+) -> Result<ApiKeyCreated, AppError> {
+    ApiKey::rotate(&state.db, key).await.map_err(|e| match e {
+        sqlx::Error::RowNotFound => AppError::unauthorized("API key not found or already inactive"),
+        other => AppError::from(other),
+    })
+}
+
+pub async fn revoke_api_key(state: &Arc<AppState>, key: &str) -> Result<(), AppError> {
+    ApiKey::revoke(&state.db, key).await.map_err(|e| match e {
+        sqlx::Error::RowNotFound => AppError::unauthorized("API key not found"),
+        other => AppError::from(other),
+    })
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin_controller;
+pub mod api_key_controller;
 pub mod creator_controller;
 pub mod export_controller;
 pub mod goal_controller;

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,7 @@ async fn main() -> anyhow::Result<()> {
             "/api/v1",
             Router::new()
                 .merge(routes::admin::router(Arc::clone(&state)))
+                .merge(routes::api_keys::router(Arc::clone(&state)))
                 .merge(routes::verification::admin_router(Arc::clone(&state)))
                 .merge(
                     Router::new()
@@ -144,6 +145,7 @@ async fn main() -> anyhow::Result<()> {
         "/api/v2",
         Router::new()
             .merge(routes::admin::router(Arc::clone(&state)))
+            .merge(routes::api_keys::router(Arc::clone(&state)))
             .merge(routes::verification::admin_router(Arc::clone(&state)))
             .merge(
                 Router::new()

--- a/src/middleware/api_key_auth.rs
+++ b/src/middleware/api_key_auth.rs
@@ -1,0 +1,41 @@
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use std::sync::Arc;
+
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::api_key::ApiKey;
+
+/// Axum middleware that validates `X-API-Key` + `X-API-Secret` headers.
+/// Injects the verified `ApiKey` into request extensions and increments usage.
+pub async fn require_api_key(
+    State(state): State<Arc<AppState>>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    let key = header_str(req.headers(), "x-api-key");
+    let secret = header_str(req.headers(), "x-api-secret");
+
+    let (Some(key), Some(secret)) = (key, secret) else {
+        return AppError::unauthorized("Missing X-API-Key or X-API-Secret headers").into_response();
+    };
+
+    match ApiKey::verify(&state.db, key, secret).await {
+        Ok(api_key) => {
+            ApiKey::record_usage(&state.db, &api_key.key).await;
+            req.extensions_mut().insert(api_key);
+            next.run(req).await
+        }
+        Err(_) => AppError::unauthorized("Invalid or revoked API key").into_response(),
+    }
+}
+
+fn header_str<'a>(
+    headers: &'a axum::http::HeaderMap,
+    name: &str,
+) -> Option<&'a str> {
+    headers.get(name).and_then(|v| v.to_str().ok())
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin_auth;
+pub mod api_key_auth;
 pub mod auth;
 pub mod authorization;
 pub mod cache;

--- a/src/models/api_key.rs
+++ b/src/models/api_key.rs
@@ -10,38 +10,81 @@ pub struct ApiKey {
     #[serde(skip_serializing)]
     pub secret: String,
     pub name: String,
+    pub permissions: Vec<String>,
     pub active: bool,
+    pub usage_count: i64,
     pub created_at: DateTime<Utc>,
     pub rotated_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct CreateApiKeyRequest {
     pub name: String,
+    #[serde(default)]
+    pub permissions: Vec<String>,
 }
 
+/// Returned only on creation/rotation — the secret is never retrievable again.
 #[derive(Debug, Serialize)]
 pub struct ApiKeyCreated {
     pub id: Uuid,
     pub key: String,
-    /// Returned only on creation; never stored in plaintext after this.
     pub secret: String,
     pub name: String,
+    pub permissions: Vec<String>,
     pub created_at: DateTime<Utc>,
 }
 
+/// Safe view (no secret) for list/get responses.
+#[derive(Debug, Serialize)]
+pub struct ApiKeyView {
+    pub id: Uuid,
+    pub key: String,
+    pub name: String,
+    pub permissions: Vec<String>,
+    pub active: bool,
+    pub usage_count: i64,
+    pub created_at: DateTime<Utc>,
+    pub rotated_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl From<ApiKey> for ApiKeyView {
+    fn from(k: ApiKey) -> Self {
+        Self {
+            id: k.id,
+            key: k.key,
+            name: k.name,
+            permissions: k.permissions,
+            active: k.active,
+            usage_count: k.usage_count,
+            created_at: k.created_at,
+            rotated_at: k.rotated_at,
+            revoked_at: k.revoked_at,
+        }
+    }
+}
+
 impl ApiKey {
-    pub async fn create(pool: &PgPool, name: &str) -> Result<ApiKeyCreated, sqlx::Error> {
-        let key = generate_key();
-        let secret = generate_key();
+    pub async fn create(
+        pool: &PgPool,
+        name: &str,
+        permissions: &[String],
+    ) -> Result<ApiKeyCreated, sqlx::Error> {
+        let key = generate_key("tjk");
+        let secret = generate_key("tjs");
 
         let row: ApiKey = sqlx::query_as(
-            "INSERT INTO api_keys (key, secret, name) VALUES ($1, $2, $3)
-             RETURNING id, key, secret, name, active, created_at, rotated_at",
+            "INSERT INTO api_keys (key, secret, name, permissions)
+             VALUES ($1, $2, $3, $4)
+             RETURNING id, key, secret, name, permissions, active, usage_count,
+                       created_at, rotated_at, revoked_at",
         )
         .bind(&key)
         .bind(&secret)
         .bind(name)
+        .bind(permissions)
         .fetch_one(pool)
         .await?;
 
@@ -50,55 +93,88 @@ impl ApiKey {
             key: row.key,
             secret,
             name: row.name,
+            permissions: row.permissions,
             created_at: row.created_at,
         })
     }
 
-    pub async fn get_secret(pool: &PgPool, key: &str) -> Result<String, sqlx::Error> {
-        let (secret,): (String,) = sqlx::query_as(
-            "SELECT secret FROM api_keys WHERE key = $1 AND active = true",
+    pub async fn list(pool: &PgPool) -> Result<Vec<ApiKey>, sqlx::Error> {
+        sqlx::query_as(
+            "SELECT id, key, secret, name, permissions, active, usage_count,
+                    created_at, rotated_at, revoked_at
+             FROM api_keys ORDER BY created_at DESC",
+        )
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn get_by_key(pool: &PgPool, key: &str) -> Result<ApiKey, sqlx::Error> {
+        sqlx::query_as(
+            "SELECT id, key, secret, name, permissions, active, usage_count,
+                    created_at, rotated_at, revoked_at
+             FROM api_keys WHERE key = $1",
+        )
+        .bind(key)
+        .fetch_one(pool)
+        .await
+    }
+
+    /// Verify key+secret and return the key row if valid and not revoked.
+    pub async fn verify(pool: &PgPool, key: &str, secret: &str) -> Result<ApiKey, sqlx::Error> {
+        sqlx::query_as(
+            "SELECT id, key, secret, name, permissions, active, usage_count,
+                    created_at, rotated_at, revoked_at
+             FROM api_keys
+             WHERE key = $1 AND secret = $2 AND active = true AND revoked_at IS NULL",
+        )
+        .bind(key)
+        .bind(secret)
+        .fetch_one(pool)
+        .await
+    }
+
+    /// Increment usage counter (fire-and-forget; ignore errors).
+    pub async fn record_usage(pool: &PgPool, key: &str) {
+        let _ = sqlx::query("UPDATE api_keys SET usage_count = usage_count + 1 WHERE key = $1")
+            .bind(key)
+            .execute(pool)
+            .await;
+    }
+
+    /// Rotate: deactivate old key, create a new one with the same name + permissions.
+    pub async fn rotate(pool: &PgPool, key: &str) -> Result<ApiKeyCreated, sqlx::Error> {
+        let row: ApiKey = sqlx::query_as(
+            "UPDATE api_keys SET active = false, rotated_at = NOW()
+             WHERE key = $1 AND active = true AND revoked_at IS NULL
+             RETURNING id, key, secret, name, permissions, active, usage_count,
+                       created_at, rotated_at, revoked_at",
         )
         .bind(key)
         .fetch_one(pool)
         .await?;
-        Ok(secret)
+
+        Self::create(pool, &row.name, &row.permissions).await
     }
 
-    /// Rotate: deactivate old key and create a new one with the same name.
-    pub async fn rotate(pool: &PgPool, key: &str) -> Result<ApiKeyCreated, sqlx::Error> {
-        let (name,): (String,) =
-            sqlx::query_as("SELECT name FROM api_keys WHERE key = $1 AND active = true")
-                .bind(key)
-                .fetch_one(pool)
-                .await?;
-
+    /// Revoke: permanently disable the key.
+    pub async fn revoke(pool: &PgPool, key: &str) -> Result<(), sqlx::Error> {
         sqlx::query(
-            "UPDATE api_keys SET active = false, rotated_at = NOW() WHERE key = $1",
+            "UPDATE api_keys SET active = false, revoked_at = NOW()
+             WHERE key = $1 AND revoked_at IS NULL",
         )
         .bind(key)
         .execute(pool)
         .await?;
-
-        Self::create(pool, &name).await
+        Ok(())
     }
 }
 
-fn generate_key() -> String {
-    use std::fmt::Write;
-    let bytes: [u8; 32] = rand_bytes();
-    let mut s = String::with_capacity(64);
-    for b in bytes {
-        write!(s, "{:02x}", b).unwrap();
-    }
-    s
-}
-
-fn rand_bytes() -> [u8; 32] {
-    // Use the OS random source via uuid's v4 internals (already a dep).
-    let id = Uuid::new_v4();
-    let id2 = Uuid::new_v4();
-    let mut out = [0u8; 32];
-    out[..16].copy_from_slice(id.as_bytes());
-    out[16..].copy_from_slice(id2.as_bytes());
-    out
+/// Generates a prefixed, cryptographically random hex key.
+fn generate_key(prefix: &str) -> String {
+    let id1 = uuid::Uuid::new_v4();
+    let id2 = uuid::Uuid::new_v4();
+    let mut bytes = [0u8; 32];
+    bytes[..16].copy_from_slice(id1.as_bytes());
+    bytes[16..].copy_from_slice(id2.as_bytes());
+    format!("{}_{}", prefix, hex::encode(bytes))
 }

--- a/src/routes/api_keys.rs
+++ b/src/routes/api_keys.rs
@@ -1,0 +1,59 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post},
+    Json, Router,
+};
+use std::sync::Arc;
+
+use crate::controllers::api_key_controller;
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::api_key::CreateApiKeyRequest;
+
+pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api-keys", post(create).get(list))
+        .route("/api-keys/:key", get(get_key))
+        .route("/api-keys/:key/rotate", post(rotate))
+        .route("/api-keys/:key/revoke", delete(revoke))
+        .with_state(state)
+}
+
+async fn create(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<CreateApiKeyRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let created = api_key_controller::create_api_key(&state, body).await?;
+    Ok((StatusCode::CREATED, Json(created)))
+}
+
+async fn list(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, AppError> {
+    let keys = api_key_controller::list_api_keys(&state).await?;
+    Ok((StatusCode::OK, Json(keys)))
+}
+
+async fn get_key(
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let view = api_key_controller::get_api_key(&state, &key).await?;
+    Ok((StatusCode::OK, Json(view)))
+}
+
+async fn rotate(
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let created = api_key_controller::rotate_api_key(&state, &key).await?;
+    Ok((StatusCode::OK, Json(created)))
+}
+
+async fn revoke(
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    api_key_controller::revoke_api_key(&state, &key).await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod api_keys;
 pub mod auth;
 pub mod creators;
 pub mod export;


### PR DESCRIPTION
- Add migration 0029: permissions[], usage_count, revoked_at columns
- ApiKey model: create, list, get, verify, rotate, revoke, record_usage
- api_key_controller: thin layer mapping DB errors to AppError
- api_key_auth middleware: X-API-Key + X-API-Secret header validation with usage tracking
- api_keys routes: POST /api-keys, GET /api-keys, GET /api-keys/:key, POST /api-keys/:key/rotate, DELETE /api-keys/:key/revoke
- Mounted under /api/v1 and /api/v2
closes #164 