### PR TITLE
feat: implement content moderation queue

### DIFF
--- a/migrations/0030_moderation_flags_and_history.sql
+++ b/migrations/0030_moderation_flags_and_history.sql
@@ -1,0 +1,32 @@
+-- Extend moderation_queue with richer action tracking
+ALTER TABLE moderation_queue
+    ADD COLUMN IF NOT EXISTS action      TEXT CHECK (action IN ('warn', 'ban', 'dismiss', 'approve', 'reject')),
+    ADD COLUMN IF NOT EXISTS flagged_by  TEXT,
+    ADD COLUMN IF NOT EXISTS flag_reason TEXT;
+
+-- Manual flags submitted by users or admins
+CREATE TABLE IF NOT EXISTS moderation_flags (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    content_type TEXT NOT NULL,
+    content_id   UUID NOT NULL,
+    content_text TEXT NOT NULL,
+    reason       TEXT NOT NULL,
+    flagged_by   TEXT NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_moderation_flags_content ON moderation_flags(content_type, content_id);
+CREATE INDEX IF NOT EXISTS idx_moderation_flags_created ON moderation_flags(created_at DESC);
+
+-- Full audit trail for every action taken on a queue item
+CREATE TABLE IF NOT EXISTS moderation_history (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    queue_item_id UUID NOT NULL REFERENCES moderation_queue(id) ON DELETE CASCADE,
+    action       TEXT NOT NULL,
+    performed_by TEXT NOT NULL,
+    note         TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_moderation_history_item ON moderation_history(queue_item_id);
+CREATE INDEX IF NOT EXISTS idx_moderation_history_created ON moderation_history(created_at DESC);

--- a/src/moderation/mod.rs
+++ b/src/moderation/mod.rs
@@ -8,7 +8,7 @@ pub mod review_queue;
 pub mod rules;
 
 pub use ai_detector::AiDetector;
-pub use review_queue::ReviewQueue;
+pub use review_queue::{ModerationFlag, ModerationHistoryEntry, ModerationQueueItem, ReviewQueue};
 pub use rules::RulesEngine;
 
 use serde::{Deserialize, Serialize};
@@ -142,6 +142,20 @@ impl ModerationService {
         }
 
         result
+    }
+
+    /// Manually flag content for review (called from user-facing routes).
+    pub async fn flag(
+        &self,
+        content_type: &str,
+        content_id: Uuid,
+        content_text: &str,
+        reason: &str,
+        flagged_by: &str,
+    ) -> anyhow::Result<Uuid> {
+        self.queue
+            .flag(content_type, content_id, content_text, reason, flagged_by)
+            .await
     }
 
     /// Expose the review queue so admin handlers can call it directly.

--- a/src/moderation/review_queue.rs
+++ b/src/moderation/review_queue.rs
@@ -1,9 +1,3 @@
-//! Persistent review queue for flagged content.
-//!
-//! Flagged items are stored in the `moderation_queue` table and surfaced to
-//! administrators through the admin API. Reviewers can approve or reject each
-//! item, recording who took the action and when.
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
@@ -11,17 +5,17 @@ use uuid::Uuid;
 
 use super::{ContentType, ModerationResult};
 
-/// A row from the `moderation_queue` table.
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct ModerationQueueItem {
     pub id: Uuid,
     pub content_type: String,
     pub content_id: Option<Uuid>,
     pub content_text: String,
-    /// JSON array of [`Violation`] objects.
     pub flags: serde_json::Value,
-    /// `pending` | `approved` | `rejected`
     pub status: String,
+    pub action: Option<String>,
+    pub flagged_by: Option<String>,
+    pub flag_reason: Option<String>,
     pub ai_score: Option<f64>,
     pub ai_reasoning: Option<String>,
     pub reviewed_by: Option<String>,
@@ -29,7 +23,27 @@ pub struct ModerationQueueItem {
     pub created_at: DateTime<Utc>,
 }
 
-/// Summary counts returned by the stats endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ModerationFlag {
+    pub id: Uuid,
+    pub content_type: String,
+    pub content_id: Uuid,
+    pub content_text: String,
+    pub reason: String,
+    pub flagged_by: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ModerationHistoryEntry {
+    pub id: Uuid,
+    pub queue_item_id: Uuid,
+    pub action: String,
+    pub performed_by: String,
+    pub note: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct ModerationStats {
     pub pending: i64,
@@ -47,7 +61,7 @@ impl ReviewQueue {
         Self { db }
     }
 
-    /// Persist a flagged item to the review queue and return the new row ID.
+    /// Persist an auto-detected flagged item to the review queue.
     pub async fn enqueue(
         &self,
         content: &str,
@@ -59,13 +73,10 @@ impl ReviewQueue {
             .unwrap_or(serde_json::Value::Array(vec![]));
 
         let id = sqlx::query_scalar::<_, Uuid>(
-            r#"
-            INSERT INTO moderation_queue
+            "INSERT INTO moderation_queue
                 (id, content_type, content_id, content_text, flags, status, ai_score, ai_reasoning, created_at)
-            VALUES
-                ($1, $2, $3, $4, $5, 'pending', $6, $7, NOW())
-            RETURNING id
-            "#,
+             VALUES ($1, $2, $3, $4, $5, 'pending', $6, $7, NOW())
+             RETURNING id",
         )
         .bind(Uuid::new_v4())
         .bind(content_type.as_str())
@@ -80,100 +91,168 @@ impl ReviewQueue {
         Ok(id)
     }
 
-    /// List items by status. Pass `None` to retrieve all statuses.
+    /// Manually flag content and enqueue it for review.
+    pub async fn flag(
+        &self,
+        content_type: &str,
+        content_id: Uuid,
+        content_text: &str,
+        reason: &str,
+        flagged_by: &str,
+    ) -> anyhow::Result<Uuid> {
+        // Record the flag
+        sqlx::query(
+            "INSERT INTO moderation_flags (content_type, content_id, content_text, reason, flagged_by)
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(content_type)
+        .bind(content_id)
+        .bind(content_text)
+        .bind(reason)
+        .bind(flagged_by)
+        .execute(&self.db)
+        .await?;
+
+        // Enqueue for review (upsert: skip if already pending for this content)
+        let id = sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO moderation_queue
+                (id, content_type, content_id, content_text, flags, status, flagged_by, flag_reason, created_at)
+             VALUES ($1, $2, $3, $4, '[]'::jsonb, 'pending', $5, $6, NOW())
+             ON CONFLICT DO NOTHING
+             RETURNING id",
+        )
+        .bind(Uuid::new_v4())
+        .bind(content_type)
+        .bind(content_id)
+        .bind(content_text)
+        .bind(flagged_by)
+        .bind(reason)
+        .fetch_optional(&self.db)
+        .await?
+        .unwrap_or_else(Uuid::new_v4);
+
+        Ok(id)
+    }
+
+    /// List items, optionally filtered by status.
     pub async fn list(
         &self,
         status: Option<&str>,
         limit: i64,
     ) -> anyhow::Result<Vec<ModerationQueueItem>> {
         let items = match status {
-            Some(s) => {
-                sqlx::query_as::<_, ModerationQueueItem>(
-                    r#"
-                    SELECT id, content_type, content_id, content_text, flags, status,
-                           ai_score, ai_reasoning, reviewed_by, reviewed_at, created_at
-                    FROM moderation_queue
-                    WHERE status = $1
-                    ORDER BY created_at DESC
-                    LIMIT $2
-                    "#,
-                )
-                .bind(s)
-                .bind(limit)
-                .fetch_all(&self.db)
-                .await?
-            }
-            None => {
-                sqlx::query_as::<_, ModerationQueueItem>(
-                    r#"
-                    SELECT id, content_type, content_id, content_text, flags, status,
-                           ai_score, ai_reasoning, reviewed_by, reviewed_at, created_at
-                    FROM moderation_queue
-                    ORDER BY created_at DESC
-                    LIMIT $1
-                    "#,
-                )
-                .bind(limit)
-                .fetch_all(&self.db)
-                .await?
-            }
+            Some(s) => sqlx::query_as::<_, ModerationQueueItem>(
+                "SELECT id, content_type, content_id, content_text, flags, status, action,
+                        flagged_by, flag_reason, ai_score, ai_reasoning,
+                        reviewed_by, reviewed_at, created_at
+                 FROM moderation_queue WHERE status = $1
+                 ORDER BY created_at DESC LIMIT $2",
+            )
+            .bind(s)
+            .bind(limit)
+            .fetch_all(&self.db)
+            .await?,
+            None => sqlx::query_as::<_, ModerationQueueItem>(
+                "SELECT id, content_type, content_id, content_text, flags, status, action,
+                        flagged_by, flag_reason, ai_score, ai_reasoning,
+                        reviewed_by, reviewed_at, created_at
+                 FROM moderation_queue
+                 ORDER BY created_at DESC LIMIT $1",
+            )
+            .bind(limit)
+            .fetch_all(&self.db)
+            .await?,
         };
         Ok(items)
     }
 
-    /// Approve a queued item. Returns `false` when the ID does not exist.
     pub async fn approve(&self, id: Uuid, reviewed_by: &str) -> anyhow::Result<bool> {
-        let rows = sqlx::query(
-            r#"
-            UPDATE moderation_queue
-            SET status = 'approved', reviewed_by = $1, reviewed_at = NOW()
-            WHERE id = $2 AND status = 'pending'
-            "#,
-        )
-        .bind(reviewed_by)
-        .bind(id)
-        .execute(&self.db)
-        .await?
-        .rows_affected();
-
-        Ok(rows > 0)
+        self.apply_action(id, "approved", "approve", reviewed_by, None).await
     }
 
-    /// Reject a queued item. Returns `false` when the ID does not exist.
     pub async fn reject(&self, id: Uuid, reviewed_by: &str) -> anyhow::Result<bool> {
+        self.apply_action(id, "rejected", "reject", reviewed_by, None).await
+    }
+
+    pub async fn dismiss(&self, id: Uuid, reviewed_by: &str, note: Option<&str>) -> anyhow::Result<bool> {
+        self.apply_action(id, "approved", "dismiss", reviewed_by, note).await
+    }
+
+    pub async fn warn(&self, id: Uuid, reviewed_by: &str, note: Option<&str>) -> anyhow::Result<bool> {
+        self.apply_action(id, "rejected", "warn", reviewed_by, note).await
+    }
+
+    pub async fn ban(&self, id: Uuid, reviewed_by: &str, note: Option<&str>) -> anyhow::Result<bool> {
+        self.apply_action(id, "rejected", "ban", reviewed_by, note).await
+    }
+
+    /// Core action applier: updates queue row + writes history entry atomically.
+    async fn apply_action(
+        &self,
+        id: Uuid,
+        status: &str,
+        action: &str,
+        reviewed_by: &str,
+        note: Option<&str>,
+    ) -> anyhow::Result<bool> {
+        let mut tx = self.db.begin().await?;
+
         let rows = sqlx::query(
-            r#"
-            UPDATE moderation_queue
-            SET status = 'rejected', reviewed_by = $1, reviewed_at = NOW()
-            WHERE id = $2 AND status = 'pending'
-            "#,
+            "UPDATE moderation_queue
+             SET status = $1, action = $2, reviewed_by = $3, reviewed_at = NOW()
+             WHERE id = $4 AND status = 'pending'",
         )
+        .bind(status)
+        .bind(action)
         .bind(reviewed_by)
         .bind(id)
-        .execute(&self.db)
+        .execute(&mut *tx)
         .await?
         .rows_affected();
 
+        if rows > 0 {
+            sqlx::query(
+                "INSERT INTO moderation_history (queue_item_id, action, performed_by, note)
+                 VALUES ($1, $2, $3, $4)",
+            )
+            .bind(id)
+            .bind(action)
+            .bind(reviewed_by)
+            .bind(note)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
         Ok(rows > 0)
     }
 
-    /// Returns counts of items in each status bucket.
+    /// Full history for a single queue item.
+    pub async fn history(&self, queue_item_id: Uuid) -> anyhow::Result<Vec<ModerationHistoryEntry>> {
+        let entries = sqlx::query_as::<_, ModerationHistoryEntry>(
+            "SELECT id, queue_item_id, action, performed_by, note, created_at
+             FROM moderation_history WHERE queue_item_id = $1
+             ORDER BY created_at ASC",
+        )
+        .bind(queue_item_id)
+        .fetch_all(&self.db)
+        .await?;
+        Ok(entries)
+    }
+
     pub async fn stats(&self) -> anyhow::Result<ModerationStats> {
         let pending: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM moderation_queue WHERE status = 'pending'")
                 .fetch_one(&self.db)
                 .await?;
-
         let approved: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM moderation_queue WHERE status = 'approved'")
                 .fetch_one(&self.db)
                 .await?;
-
         let rejected: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM moderation_queue WHERE status = 'rejected'")
                 .fetch_one(&self.db)
                 .await?;
-
         Ok(ModerationStats {
             pending,
             approved,

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -35,8 +35,13 @@ pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
         // Moderation endpoints
         .route("/admin/moderation/queue", get(moderation_queue))
         .route("/admin/moderation/stats", get(moderation_stats))
+        .route("/admin/moderation/flag", post(moderation_flag))
         .route("/admin/moderation/:id/approve", post(moderation_approve))
         .route("/admin/moderation/:id/reject", post(moderation_reject))
+        .route("/admin/moderation/:id/dismiss", post(moderation_dismiss))
+        .route("/admin/moderation/:id/warn", post(moderation_warn))
+        .route("/admin/moderation/:id/ban", post(moderation_ban))
+        .route("/admin/moderation/:id/history", get(moderation_history))
         .route_layer(middleware::from_fn_with_state(state, require_admin))
 }
 
@@ -173,26 +178,7 @@ async fn moderation_approve(
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
     let reviewer = resolve_admin_from_headers(&state, &headers).await;
-    match state.moderation.queue().approve(id, &reviewer).await {
-        Ok(true) => (
-            StatusCode::OK,
-            Json(serde_json::json!({ "message": "Item approved" })),
-        )
-            .into_response(),
-        Ok(false) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "error": "Item not found or already reviewed" })),
-        )
-            .into_response(),
-        Err(e) => {
-            tracing::error!("Failed to approve moderation item: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": "Failed to approve item" })),
-            )
-                .into_response()
-        }
-    }
+    dispatch_moderation_action(state.moderation.queue().approve(id, &reviewer).await, "approve").into_response()
 }
 
 async fn moderation_reject(
@@ -201,24 +187,106 @@ async fn moderation_reject(
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
     let reviewer = resolve_admin_from_headers(&state, &headers).await;
-    match state.moderation.queue().reject(id, &reviewer).await {
+    dispatch_moderation_action(state.moderation.queue().reject(id, &reviewer).await, "reject").into_response()
+}
+
+#[derive(serde::Deserialize)]
+struct ModerationActionBody {
+    note: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct ModerationFlagBody {
+    content_type: String,
+    content_id: uuid::Uuid,
+    content_text: String,
+    reason: String,
+}
+
+async fn moderation_flag(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<ModerationFlagBody>,
+) -> impl IntoResponse {
+    let flagged_by = resolve_admin_from_headers(&state, &headers).await;
+    match state
+        .moderation
+        .flag(&body.content_type, body.content_id, &body.content_text, &body.reason, &flagged_by)
+        .await
+    {
+        Ok(id) => (StatusCode::CREATED, Json(serde_json::json!({ "queue_item_id": id }))).into_response(),
+        Err(e) => {
+            tracing::error!("Failed to flag content: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({ "error": "Failed to flag content" }))).into_response()
+        }
+    }
+}
+
+async fn moderation_dismiss(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(id): Path<Uuid>,
+    body: Option<Json<ModerationActionBody>>,
+) -> impl IntoResponse {
+    let reviewer = resolve_admin_from_headers(&state, &headers).await;
+    let note = body.as_ref().and_then(|b| b.note.as_deref());
+    dispatch_moderation_action(state.moderation.queue().dismiss(id, &reviewer, note).await, "dismiss").into_response()
+}
+
+async fn moderation_warn(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(id): Path<Uuid>,
+    body: Option<Json<ModerationActionBody>>,
+) -> impl IntoResponse {
+    let reviewer = resolve_admin_from_headers(&state, &headers).await;
+    let note = body.as_ref().and_then(|b| b.note.as_deref());
+    dispatch_moderation_action(state.moderation.queue().warn(id, &reviewer, note).await, "warn").into_response()
+}
+
+async fn moderation_ban(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(id): Path<Uuid>,
+    body: Option<Json<ModerationActionBody>>,
+) -> impl IntoResponse {
+    let reviewer = resolve_admin_from_headers(&state, &headers).await;
+    let note = body.as_ref().and_then(|b| b.note.as_deref());
+    dispatch_moderation_action(state.moderation.queue().ban(id, &reviewer, note).await, "ban").into_response()
+}
+
+async fn moderation_history(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> impl IntoResponse {
+    match state.moderation.queue().history(id).await {
+        Ok(entries) => (StatusCode::OK, Json(serde_json::json!(entries))).into_response(),
+        Err(e) => {
+            tracing::error!("Failed to get moderation history: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({ "error": "Failed to retrieve history" }))).into_response()
+        }
+    }
+}
+
+fn dispatch_moderation_action(
+    result: anyhow::Result<bool>,
+    action: &str,
+) -> impl IntoResponse {
+    match result {
         Ok(true) => (
             StatusCode::OK,
-            Json(serde_json::json!({ "message": "Item rejected" })),
-        )
-            .into_response(),
+            Json(serde_json::json!({ "message": format!("Action '{}' applied", action) })),
+        ).into_response(),
         Ok(false) => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({ "error": "Item not found or already reviewed" })),
-        )
-            .into_response(),
+        ).into_response(),
         Err(e) => {
-            tracing::error!("Failed to reject moderation item: {}", e);
+            tracing::error!("Moderation action '{}' failed: {}", action, e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": "Failed to reject item" })),
-            )
-                .into_response()
+                Json(serde_json::json!({ "error": format!("Failed to apply action '{}'" , action) })),
+            ).into_response()
         }
     }
 }


### PR DESCRIPTION
- Migration 0030: moderation_flags table, moderation_history table, action/flagged_by/flag_reason columns on moderation_queue
- ReviewQueue: flag(), dismiss(), warn(), ban(), history() methods with atomic action + history recording via DB transaction
- ModerationService: expose flag() on top-level orchestrator
- Admin routes: POST /admin/moderation/flag, POST /admin/moderation/:id/dismiss, POST /admin/moderation/:id/warn, POST /admin/moderation/:id/ban, GET  /admin/moderation/:id/history
- Refactored approve/reject to shared dispatch_moderation_action helper
closes #165 