### PR TITLE
feat: implement Stellar transaction monitoring and graceful shutdown

### DIFF
--- a/migrations/0039_add_tip_verified_column.down.sql
+++ b/migrations/0039_add_tip_verified_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tips DROP COLUMN IF EXISTS verified;

--- a/migrations/0039_add_tip_verified_column.sql
+++ b/migrations/0039_add_tip_verified_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tips ADD COLUMN IF NOT EXISTS verified BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_tips_unverified ON tips(verified) WHERE verified = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,9 @@ async fn main() -> anyhow::Result<()> {
     // Start background job processing system
     let (_job_queue, _job_scheduler) = jobs::start(Arc::clone(&state), jobs::JobConfig::default());
 
+    // Start Stellar transaction monitoring (#175)
+    let monitor = services::monitoring_service::spawn(Arc::clone(&state));
+
     // --- Currency service ---
     let currency_svc = Arc::new(currency::CurrencyService::new());
     // Refresh exchange rates every hour in the background.
@@ -243,6 +246,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/metrics", axum::routing::get(metrics_handler))
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        .merge(routes::monitoring::router(Arc::clone(&state), Arc::clone(&monitor)))
         .merge(v1)
         .merge(v2)
         .layer(axum::Extension(gql_schema))
@@ -287,10 +291,22 @@ async fn main() -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("Server listening on {}", addr);
 
+    // Graceful shutdown (#177): complete in-flight requests, then stop.
+    let shutdown_timeout = shutdown::shutdown_timeout();
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
     )
+    .with_graceful_shutdown(async move {
+        shutdown::shutdown_signal().await;
+        tracing::info!(
+            timeout_secs = shutdown_timeout.as_secs(),
+            "Waiting for in-flight requests to complete…"
+        );
+        tokio::time::sleep(shutdown_timeout).await;
+        monitor.stop().await;
+        tracing::info!("Graceful shutdown complete");
+    })
     .await?;
 
     Ok(())

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -13,6 +13,7 @@ pub mod goals;
 pub mod health;
 pub mod ip_blocking;
 pub mod leaderboard;
+pub mod monitoring;
 pub mod notifications;
 pub mod refunds;
 pub mod scheduled_tips;

--- a/src/routes/monitoring.rs
+++ b/src/routes/monitoring.rs
@@ -1,0 +1,42 @@
+use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::db::connection::AppState;
+use crate::services::monitoring_service::MonitoringService;
+
+/// GET /monitoring/dashboard
+///
+/// Returns a snapshot of the Stellar transaction monitoring stats plus
+/// current database pool and circuit-breaker state.
+pub async fn dashboard(
+    State((state, monitor)): State<(Arc<AppState>, Arc<MonitoringService>)>,
+) -> impl IntoResponse {
+    let snap = monitor.stats.snapshot();
+    let pool = &state.db;
+    let cb_state = state.db_circuit_breaker.state();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "stellar_monitoring": {
+                "transactions_checked":  snap.transactions_checked,
+                "transactions_verified": snap.transactions_verified,
+                "transactions_failed":   snap.transactions_failed,
+                "network_errors":        snap.network_errors,
+            },
+            "database": {
+                "pool_size": pool.size(),
+                "pool_idle": pool.num_idle(),
+                "circuit_breaker": format!("{:?}", cb_state),
+            },
+            "stellar_network": state.stellar.network,
+        })),
+    )
+}
+
+pub fn router(state: Arc<AppState>, monitor: Arc<MonitoringService>) -> Router {
+    Router::new()
+        .route("/monitoring/dashboard", get(dashboard))
+        .with_state((state, monitor))
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth_service;
 pub mod circuit_breaker;
 pub mod creator_service;
+pub mod monitoring_service;
 pub mod retry;
 pub mod scheduled_tip_service;
 pub mod stellar_service;

--- a/src/services/monitoring_service.rs
+++ b/src/services/monitoring_service.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+use tokio::time::interval;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use crate::db::connection::AppState;
+use crate::services::stellar_service::StellarService;
+
+/// Rolling stats for the monitoring dashboard.
+#[derive(Debug, Default)]
+pub struct MonitoringStats {
+    pub transactions_checked: AtomicU64,
+    pub transactions_verified: AtomicU64,
+    pub transactions_failed: AtomicU64,
+    pub network_errors: AtomicU64,
+}
+
+impl MonitoringStats {
+    pub fn snapshot(&self) -> MonitoringSnapshot {
+        MonitoringSnapshot {
+            transactions_checked: self.transactions_checked.load(Ordering::Relaxed),
+            transactions_verified: self.transactions_verified.load(Ordering::Relaxed),
+            transactions_failed: self.transactions_failed.load(Ordering::Relaxed),
+            network_errors: self.network_errors.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct MonitoringSnapshot {
+    pub transactions_checked: u64,
+    pub transactions_verified: u64,
+    pub transactions_failed: u64,
+    pub network_errors: u64,
+}
+
+/// Monitors unverified tips in the database and attempts to verify them
+/// against the Stellar network, auto-recording them when confirmed.
+pub struct MonitoringService {
+    stellar: StellarService,
+    pub stats: Arc<MonitoringStats>,
+    poll_interval: Duration,
+    shutdown: Arc<RwLock<bool>>,
+}
+
+impl MonitoringService {
+    pub fn new(stellar: StellarService, poll_interval: Duration) -> Self {
+        Self {
+            stellar,
+            stats: Arc::new(MonitoringStats::default()),
+            poll_interval,
+            shutdown: Arc::new(RwLock::new(false)),
+        }
+    }
+
+    /// Signal the monitoring loop to stop.
+    pub async fn stop(&self) {
+        *self.shutdown.write().await = true;
+    }
+
+    /// Poll the database for pending (unverified) tips and verify each one
+    /// against the Stellar Horizon API.
+    pub async fn run(&self, state: Arc<AppState>) {
+        info!(
+            interval_secs = self.poll_interval.as_secs(),
+            "Stellar transaction monitor started"
+        );
+
+        let mut ticker = interval(self.poll_interval);
+
+        loop {
+            ticker.tick().await;
+
+            if *self.shutdown.read().await {
+                info!("Stellar transaction monitor shutting down");
+                break;
+            }
+
+            if let Err(e) = self.poll_pending_tips(&state).await {
+                error!(error = %e, "Error polling pending tips");
+            }
+        }
+    }
+
+    async fn poll_pending_tips(&self, state: &Arc<AppState>) -> Result<(), sqlx::Error> {
+        // Fetch tips that have not yet been confirmed.
+        let rows: Vec<(Uuid, String)> = sqlx::query_as(
+            "SELECT id, transaction_hash FROM tips WHERE verified = false ORDER BY created_at ASC LIMIT 50",
+        )
+        .fetch_all(&state.db)
+        .await?;
+
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        info!(count = rows.len(), "Checking unverified tips");
+
+        for (id, hash) in rows {
+            self.stats
+                .transactions_checked
+                .fetch_add(1, Ordering::Relaxed);
+
+            let start = Instant::now();
+
+            match self.stellar.verify_transaction(&hash).await {
+                Ok(true) => {
+                    self.stats
+                        .transactions_verified
+                        .fetch_add(1, Ordering::Relaxed);
+
+                    sqlx::query("UPDATE tips SET verified = true WHERE id = $1")
+                        .bind(id)
+                        .execute(&state.db)
+                        .await?;
+
+                    info!(
+                        tx_hash = %hash,
+                        elapsed_ms = start.elapsed().as_millis(),
+                        "Tip verified and marked confirmed"
+                    );
+                }
+                Ok(false) => {
+                    self.stats
+                        .transactions_failed
+                        .fetch_add(1, Ordering::Relaxed);
+
+                    warn!(tx_hash = %hash, "Transaction not found or unsuccessful on Stellar");
+                }
+                Err(e) => {
+                    self.stats
+                        .network_errors
+                        .fetch_add(1, Ordering::Relaxed);
+
+                    error!(tx_hash = %hash, error = %e, "Network error verifying transaction");
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Spawn the monitoring loop as a background Tokio task.
+/// Returns the service handle so callers can read stats or stop it.
+pub fn spawn(state: Arc<AppState>) -> Arc<MonitoringService> {
+    let poll_interval = Duration::from_secs(
+        std::env::var("MONITORING_POLL_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30),
+    );
+
+    let svc = Arc::new(MonitoringService::new(state.stellar.clone(), poll_interval));
+    let svc_clone = Arc::clone(&svc);
+
+    tokio::spawn(async move {
+        svc_clone.run(state).await;
+    });
+
+    svc
+}

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,5 +1,7 @@
+use std::time::Duration;
 use tokio::signal;
 
+/// Wait for SIGINT (Ctrl-C) or SIGTERM.
 pub async fn shutdown_signal() {
     let ctrl_c = async {
         signal::ctrl_c()
@@ -23,5 +25,15 @@ pub async fn shutdown_signal() {
         _ = terminate => {},
     }
 
-    tracing::info!("Shutdown signal received, draining in-flight requests...");
+    tracing::info!("Shutdown signal received, draining in-flight requests…");
+}
+
+/// Returns the graceful-shutdown timeout from `SHUTDOWN_TIMEOUT_SECS` env var,
+/// defaulting to 30 seconds.
+pub fn shutdown_timeout() -> Duration {
+    std::env::var("SHUTDOWN_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(30))
 }


### PR DESCRIPTION
## Summary

Implements two features in a single PR:

### #175 — Stellar Transaction Monitoring
- **Migration** `0039_add_tip_verified_column`: adds `verified BOOLEAN NOT NULL DEFAULT false` to the `tips` table with a partial index on unverified rows
- **`MonitoringService`** (`src/services/monitoring_service.rs`): background task that polls unverified tips every N seconds (default 30, configurable via `MONITORING_POLL_SECS`), calls the Stellar Horizon API to verify each transaction, and marks confirmed tips `verified = true`
- **`GET /monitoring/dashboard`** (`src/routes/monitoring.rs`): live stats endpoint showing transactions checked/verified/failed/network-errors plus DB pool and circuit-breaker state

### #177 — Graceful Shutdown Handler
- **`shutdown_timeout()`** added to `src/shutdown.rs`: reads `SHUTDOWN_TIMEOUT_SECS` env var, defaults to 30s
- **`axum::serve` wired with `.with_graceful_shutdown()`** in `src/main.rs`: waits for SIGINT/SIGTERM, drains in-flight requests for the configured timeout, then stops the monitoring loop cleanly

## Testing
- Existing test suite: `cargo test`
- Dashboard: `GET /monitoring/dashboard`
- Shutdown: send SIGTERM and observe drain log lines

Closes #175
Closes #177