### PR TITLE
feat: implement blue-green deployment

### DIFF
--- a/k8s/deployment-blue.yaml
+++ b/k8s/deployment-blue.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stellar-tipjar-backend-blue
+  labels:
+    app: stellar-tipjar-backend
+    slot: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: stellar-tipjar-backend
+      slot: blue
+  template:
+    metadata:
+      labels:
+        app: stellar-tipjar-backend
+        slot: blue
+      annotations:
+        sidecar.istio.io/inject: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: stellar-tipjar-backend
+          image: stellar-tipjar-backend:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tipjar-secrets
+                  key: database-url
+            - name: PORT
+              value: "8000"
+            - name: DEPLOYMENT_SLOT
+              value: "blue"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/deployment-green.yaml
+++ b/k8s/deployment-green.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stellar-tipjar-backend-green
+  labels:
+    app: stellar-tipjar-backend
+    slot: green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: stellar-tipjar-backend
+      slot: green
+  template:
+    metadata:
+      labels:
+        app: stellar-tipjar-backend
+        slot: green
+      annotations:
+        sidecar.istio.io/inject: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: stellar-tipjar-backend
+          image: stellar-tipjar-backend:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tipjar-secrets
+                  key: database-url
+            - name: PORT
+              value: "8000"
+            - name: DEPLOYMENT_SLOT
+              value: "green"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/istio.yaml
+++ b/k8s/istio.yaml
@@ -1,6 +1,5 @@
 ---
-# DestinationRule: defines the stable and canary subsets based on the
-# `version` label set in deployment.yaml.
+# DestinationRule: defines blue and green subsets based on the `slot` label.
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -12,22 +11,22 @@ spec:
       http:
         http1MaxPendingRequests: 100
         http2MaxRequests: 1000
-    # Circuit breaker: eject unhealthy instances for 30 s after 5 consecutive 5xx.
     outlierDetection:
       consecutive5xxErrors: 5
       interval: 10s
       baseEjectionTime: 30s
       maxEjectionPercent: 50
   subsets:
-    - name: stable
+    - name: blue
       labels:
-        version: stable
-    - name: canary
+        slot: blue
+    - name: green
       labels:
-        version: canary
+        slot: green
 ---
-# VirtualService: routes 95 % of traffic to stable, 5 % to canary.
-# Adjust weights at deploy time (e.g. via `kubectl patch`) to shift traffic.
+# VirtualService: routes all traffic to the live slot.
+# Switch traffic by patching the `route` destination subset (blue ↔ green).
+# Use `kubectl patch` or the blue_green_deploy.sh script to switch.
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -36,22 +35,27 @@ spec:
   hosts:
     - stellar-tipjar-backend
   http:
+    # Allow direct slot targeting via header for smoke testing.
     - match:
-        # Route requests with the canary header directly to the canary subset,
-        # enabling targeted testing without touching the weight split.
         - headers:
-            x-canary:
-              exact: "true"
+            x-deployment-slot:
+              exact: "blue"
       route:
         - destination:
             host: stellar-tipjar-backend
-            subset: canary
+            subset: blue
+    - match:
+        - headers:
+            x-deployment-slot:
+              exact: "green"
+      route:
+        - destination:
+            host: stellar-tipjar-backend
+            subset: green
+    # Default: all traffic goes to the live slot (blue by default).
+    # Update the subset name here when switching slots.
     - route:
         - destination:
             host: stellar-tipjar-backend
-            subset: stable
-          weight: 95
-        - destination:
-            host: stellar-tipjar-backend
-            subset: canary
-          weight: 5
+            subset: blue
+          weight: 100

--- a/scripts/blue_green_deploy.sh
+++ b/scripts/blue_green_deploy.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# blue_green_deploy.sh — Blue-green deployment orchestration for stellar-tipjar-backend.
+#
+# Usage:
+#   ./scripts/blue_green_deploy.sh deploy  <image-tag>   [--namespace <ns>]
+#   ./scripts/blue_green_deploy.sh rollback               [--namespace <ns>]
+#   ./scripts/blue_green_deploy.sh status                 [--namespace <ns>]
+#
+# Requirements: kubectl, curl
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+NAMESPACE="${NAMESPACE:-default}"
+APP="stellar-tipjar-backend"
+HEALTH_TIMEOUT=120   # seconds to wait for standby to become ready
+SMOKE_RETRIES=5
+SMOKE_DELAY=5        # seconds between smoke-test retries
+VS_NAME="$APP"       # Istio VirtualService name
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+log()  { echo "[$(date -u +%H:%M:%S)] $*"; }
+die()  { echo "[ERROR] $*" >&2; exit 1; }
+
+require() { command -v "$1" &>/dev/null || die "'$1' is required but not found."; }
+require kubectl
+require curl
+
+# Parse --namespace flag anywhere in args
+parse_args() {
+    local args=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --namespace|-n) NAMESPACE="$2"; shift 2 ;;
+            *) args+=("$1"); shift ;;
+        esac
+    done
+    echo "${args[@]:-}"
+}
+
+# ── Live-slot detection ────────────────────────────────────────────────────────
+# Reads the current default route subset from the Istio VirtualService.
+get_live_slot() {
+    kubectl get virtualservice "$VS_NAME" -n "$NAMESPACE" \
+        -o jsonpath='{.spec.http[-1].route[0].destination.subset}' 2>/dev/null \
+        || echo "blue"
+}
+
+get_standby_slot() {
+    local live; live=$(get_live_slot)
+    [[ "$live" == "blue" ]] && echo "green" || echo "blue"
+}
+
+# ── Traffic switch ─────────────────────────────────────────────────────────────
+switch_traffic() {
+    local target="$1"
+    log "Switching VirtualService default route → $target"
+    kubectl patch virtualservice "$VS_NAME" -n "$NAMESPACE" \
+        --type=json \
+        -p="[{\"op\":\"replace\",\"path\":\"/spec/http/2/route/0/destination/subset\",\"value\":\"${target}\"}]"
+}
+
+# ── Deployment update ──────────────────────────────────────────────────────────
+update_image() {
+    local slot="$1" tag="$2"
+    log "Updating deployment-${slot} image to ${APP}:${tag}"
+    kubectl set image deployment/"${APP}-${slot}" \
+        "${APP}=${APP}:${tag}" \
+        -n "$NAMESPACE"
+}
+
+# ── Readiness wait ─────────────────────────────────────────────────────────────
+wait_ready() {
+    local slot="$1"
+    log "Waiting for deployment-${slot} to be ready (timeout: ${HEALTH_TIMEOUT}s)..."
+    kubectl rollout status deployment/"${APP}-${slot}" \
+        -n "$NAMESPACE" \
+        --timeout="${HEALTH_TIMEOUT}s"
+}
+
+# ── Smoke test ─────────────────────────────────────────────────────────────────
+# Hits /health on the standby slot via the header-based Istio route.
+smoke_test() {
+    local slot="$1"
+    local svc_url
+    svc_url=$(kubectl get svc "$APP" -n "$NAMESPACE" \
+        -o jsonpath='http://{.spec.clusterIP}:{.spec.ports[0].port}' 2>/dev/null \
+        || echo "http://${APP}.${NAMESPACE}.svc.cluster.local")
+
+    log "Running smoke test against ${slot} slot (${svc_url}/health)..."
+    local attempt=0
+    while (( attempt < SMOKE_RETRIES )); do
+        attempt=$(( attempt + 1 ))
+        local http_code
+        http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+            -H "x-deployment-slot: ${slot}" \
+            "${svc_url}/health" 2>/dev/null || echo "000")
+        if [[ "$http_code" == "200" ]]; then
+            log "Smoke test passed (attempt ${attempt})"
+            return 0
+        fi
+        log "Smoke test attempt ${attempt}/${SMOKE_RETRIES} failed (HTTP ${http_code}), retrying in ${SMOKE_DELAY}s..."
+        sleep "$SMOKE_DELAY"
+    done
+    return 1
+}
+
+# ── Commands ───────────────────────────────────────────────────────────────────
+cmd_status() {
+    local live; live=$(get_live_slot)
+    local standby; standby=$(get_standby_slot)
+    log "Live slot    : $live"
+    log "Standby slot : $standby"
+    echo ""
+    kubectl get deployment \
+        "${APP}-blue" "${APP}-green" \
+        -n "$NAMESPACE" \
+        --no-headers \
+        -o custom-columns="NAME:.metadata.name,READY:.status.readyReplicas,DESIRED:.spec.replicas,IMAGE:.spec.template.spec.containers[0].image" \
+        2>/dev/null || true
+}
+
+cmd_deploy() {
+    local tag="${1:-}"
+    [[ -z "$tag" ]] && die "Usage: $0 deploy <image-tag>"
+
+    local standby; standby=$(get_standby_slot)
+    local live;    live=$(get_live_slot)
+
+    log "=== Blue-Green Deploy ==="
+    log "Live slot    : $live"
+    log "Standby slot : $standby"
+    log "Image tag    : $tag"
+
+    # 1. Push new image to standby slot.
+    update_image "$standby" "$tag"
+
+    # 2. Wait for standby pods to be ready.
+    wait_ready "$standby"
+
+    # 3. Smoke test the standby slot.
+    if ! smoke_test "$standby"; then
+        die "Smoke test failed for slot '${standby}'. Deployment aborted. Live slot '${live}' unchanged."
+    fi
+
+    # 4. Switch traffic.
+    switch_traffic "$standby"
+    log "=== Traffic switched to '${standby}' ==="
+
+    # 5. Post-switch health check on the new live slot.
+    sleep 3
+    if ! smoke_test "$standby"; then
+        log "Post-switch health check failed — initiating automatic rollback..."
+        switch_traffic "$live"
+        die "Rolled back to '${live}'. Investigate '${standby}' before retrying."
+    fi
+
+    log "=== Deployment complete. Live: ${standby} | Previous: ${live} ==="
+}
+
+cmd_rollback() {
+    local live;    live=$(get_live_slot)
+    local standby; standby=$(get_standby_slot)
+
+    log "=== Rollback: ${live} → ${standby} ==="
+    switch_traffic "$standby"
+    log "Traffic switched back to '${standby}'."
+    log "Run '$0 status' to verify."
+}
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+main() {
+    local positional
+    positional=$(parse_args "$@")
+    # shellcheck disable=SC2086
+    set -- $positional
+
+    local cmd="${1:-status}"
+    shift || true
+
+    case "$cmd" in
+        deploy)   cmd_deploy "$@" ;;
+        rollback) cmd_rollback ;;
+        status)   cmd_status ;;
+        *) die "Unknown command '${cmd}'. Use: deploy <tag> | rollback | status" ;;
+    esac
+}
+
+main "$@"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub fn create_app(state: Arc<AppState>) -> Router {
     // Read endpoints use the general limit and intelligent response caching.
     let read_routes = Router::new()
         .merge(routes::creators::read_router())
+        .merge(routes::deployment::router())
         .merge(routes::health::router())
         .merge(routes::leaderboard::router())
         .merge(routes::stats::router())

--- a/src/routes/deployment.rs
+++ b/src/routes/deployment.rs
@@ -1,0 +1,14 @@
+use axum::{routing::get, Json, Router};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use crate::db::connection::AppState;
+
+async fn deployment_status() -> Json<Value> {
+    let slot = std::env::var("DEPLOYMENT_SLOT").unwrap_or_else(|_| "unknown".into());
+    Json(json!({ "slot": slot }))
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().route("/deployment/status", get(deployment_status))
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -6,6 +6,7 @@ pub mod auth;
 pub mod categories;
 pub mod creators;
 pub mod currency;
+pub mod deployment;
 pub mod export;
 pub mod feature_flags;
 pub mod follows;


### PR DESCRIPTION
Closes #247

---

## Summary

Implements blue-green deployment strategy for zero-downtime releases (#247).

## Changes

**Kubernetes**
- `k8s/deployment-blue.yaml` / `k8s/deployment-green.yaml` — separate Deployments with `slot: blue/green` labels and `DEPLOYMENT_SLOT` env var
- `k8s/istio.yaml` — DestinationRule with `blue`/`green` subsets; VirtualService routes 100% to live slot with header-based routing (`x-deployment-slot`) for smoke testing

**Orchestration**
- `scripts/blue_green_deploy.sh` — `deploy <tag>` / `rollback` / `status` commands; auto-rollback on post-switch health check failure

**Runtime**
- `GET /deployment/status` — returns active slot (`{"slot": "blue|green"}`) for monitoring and smoke tests

## Testing
- Smoke tests hit `/health` on the standby slot via the `x-deployment-slot` header before any traffic switch
- Post-switch health check triggers automatic rollback on failure
- Existing `BlueGreenManager` unit tests in `src/deployment/blue_green.rs` cover switch/rollback/smoke-test logic