### PR TITLE
Implement API mocking, CQRS, saga orchestration, and metrics dashboard

### DIFF
--- a/PR_DESCRIPTION_229_234_236_240.md
+++ b/PR_DESCRIPTION_229_234_236_240.md
@@ -1,0 +1,88 @@
+## Summary
+
+This PR implements four platform capabilities across testing, architecture, distributed workflows, and observability:
+
+1. API mocking infrastructure for integration tests and local development.
+2. CQRS improvements with explicit command handlers and read-model synchronization.
+3. Saga orchestration hardening for distributed transactions.
+4. Real-time metrics dashboard improvements with Prometheus recording rules and Grafana aggregation.
+
+## What Changed
+
+### #240 API Mocking for Testing
+- Added a dedicated mock server engine with runtime registration and replay:
+  - `src/mocking/server.rs`
+- Added mock data generators for creators, tips, tx hashes, IDs, emails:
+  - `src/mocking/generators.rs`
+- Upgraded request matching:
+  - wildcard/path-param matching (`*`, `:param`)
+  - query subset matching
+  - optional header constraints via `x-mock-match-*`
+- Added response template rendering:
+  - request-aware placeholders (`{{request.method}}`, `{{request.path}}`, path params)
+  - dynamic data placeholders (`{{random.uuid}}`, `{{random.tx_hash}}`, etc.)
+- Extended mock recording:
+  - JSON export/import
+  - replay into registry as mock entries
+- Added/extended tests in `tests/feature_tests.rs`.
+
+### #229 CQRS Pattern
+- Added explicit command handler abstraction and concrete handlers:
+  - `src/cqrs/handlers.rs`
+- Refactored command dispatch to use handler registry:
+  - `src/cqrs/command_bus.rs`
+- Added read-model sync report + incremental synchronization:
+  - `src/cqrs/projections.rs`
+  - `src/cqrs/synchronizer.rs`
+- Added read-optimized `CreatorSummaryView` query path:
+  - `src/cqrs/queries.rs`
+  - `src/cqrs/query_bus.rs`
+- Exported new CQRS primitives in `src/cqrs/mod.rs`.
+
+### #234 Saga Pattern for Distributed Transactions
+- Added saga step retry controls (`max_retries`, `retry_backoff_ms`):
+  - `src/saga/step.rs`
+- Updated tip saga to define retry/compensation behavior per step:
+  - `src/saga/tip_saga.rs`
+- Enhanced orchestrator:
+  - step retry loop
+  - explicit failed/compensated state transitions
+  - partial-failure compensation execution in reverse order
+  - improved failure reason propagation
+  - `src/saga/orchestrator.rs`
+- Improved compensation handler with pluggable compensation hooks:
+  - `src/saga/compensation.rs`
+- Added status aggregation query in saga monitoring:
+  - `src/saga/monitoring.rs`
+- Cleaned duplicate saga module declaration:
+  - `src/saga/mod.rs`
+
+### #236 Real-time Metrics Dashboard
+- Added business metric instrumentation in write paths:
+  - creator registration counter (`CREATORS_REGISTERED_TOTAL`)
+  - tip success/failure counters and amount histogram
+  - corrected DB query histogram labeling usage
+  - `src/controllers/creator_controller.rs`
+  - `src/controllers/tip_controller.rs`
+- Added Prometheus recording rules for metric aggregation:
+  - `monitoring/prometheus/recording_rules.yml`
+  - wired into `monitoring/prometheus/prometheus.yml`
+  - mounted in `compose.yml`
+- Updated Grafana dashboard to consume aggregated time series:
+  - `monitoring/grafana/dashboards/tipjar_overview.json`
+
+## Validation
+
+- Targeted test command attempted: `cargo test --test feature_tests api_mocking -- --nocapture`
+- Full compile/test is currently blocked by pre-existing repository issues unrelated to this PR:
+  - duplicate module declarations in other areas
+  - existing SQLx online macro requirements without prepared cache/DB
+  - existing unrelated type/trait errors in untouched modules
+
+## Issue Closure
+
+Closes #229  
+Closes #234  
+Closes #236  
+Closes #240
+

--- a/compose.yml
+++ b/compose.yml
@@ -40,6 +40,7 @@ services:
     volumes:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./monitoring/prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - ./monitoring/prometheus/recording_rules.yml:/etc/prometheus/recording_rules.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"

--- a/monitoring/grafana/dashboards/tipjar_overview.json
+++ b/monitoring/grafana/dashboards/tipjar_overview.json
@@ -12,8 +12,8 @@
       "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total[1m])) by (method)",
-          "legendFormat": "{{ method }}"
+          "expr": "tipjar:http_requests:rate_5m",
+          "legendFormat": "req/s"
         }
       ]
     },
@@ -24,7 +24,7 @@
       "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "expr": "tipjar:http_latency_p95_seconds:5m",
           "legendFormat": "p95"
         }
       ]
@@ -36,7 +36,7 @@
       "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m]))",
+          "expr": "tipjar:http_error_ratio:rate_5m",
           "legendFormat": "error rate"
         }
       ]
@@ -115,8 +115,8 @@
       "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
       "targets": [
         {
-          "expr": "sum(rate(cache_hits_total[5m])) by (layer) / (sum(rate(cache_hits_total[5m])) by (layer) + sum(rate(cache_misses_total[5m])) by (layer))",
-          "legendFormat": "{{ layer }}"
+          "expr": "tipjar:cache_hit_ratio:rate_5m",
+          "legendFormat": "cache hit ratio"
         }
       ]
     }

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -4,6 +4,7 @@ global:
 
 rule_files:
   - "alerts.yml"
+  - "recording_rules.yml"
 
 alerting:
   alertmanagers:

--- a/monitoring/prometheus/recording_rules.yml
+++ b/monitoring/prometheus/recording_rules.yml
@@ -1,0 +1,28 @@
+groups:
+  - name: tipjar_recording_rules
+    interval: 30s
+    rules:
+      - record: tipjar:http_requests:rate_5m
+        expr: sum(rate(http_requests_total[5m]))
+
+      - record: tipjar:http_error_ratio:rate_5m
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+          /
+          clamp_min(sum(rate(http_requests_total[5m])), 1)
+
+      - record: tipjar:http_latency_p95_seconds:5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le)
+          )
+
+      - record: tipjar:tips_created:rate_5m
+        expr: sum(rate(tips_created_total[5m]))
+
+      - record: tipjar:cache_hit_ratio:rate_5m
+        expr: |
+          sum(rate(cache_hits_total[5m]))
+          /
+          clamp_min(sum(rate(cache_hits_total[5m])) + sum(rate(cache_misses_total[5m])), 1)

--- a/src/controllers/creator_controller.rs
+++ b/src/controllers/creator_controller.rs
@@ -5,8 +5,9 @@ use crate::cache::{keys, redis_client};
 use crate::db::connection::AppState;
 use crate::db::query_logger::QueryLogger;
 use crate::errors::{AppError, AppResult, ValidationError};
-use crate::moderation::ContentType;
+use crate::metrics::collectors::CREATORS_REGISTERED_TOTAL;
 use crate::models::creator::{CreateCreatorRequest, Creator};
+use crate::moderation::ContentType;
 use crate::search::SearchQuery;
 use sqlx::PgPool;
 
@@ -42,6 +43,7 @@ pub async fn create_creator(state: &AppState, req: CreateCreatorRequest) -> AppR
     QueryLogger::log_query(query, duration);
     state.performance.track_query(query, duration);
     tracing::info!(duration_ms = duration.as_millis(), "Creator created");
+    CREATORS_REGISTERED_TOTAL.inc();
 
     // Cache the new creator and invalidate any stale search results.
     if let Some(conn) = state.redis.as_ref() {
@@ -58,7 +60,9 @@ pub async fn create_creator(state: &AppState, req: CreateCreatorRequest) -> AppR
     // Centralized invalidation for search and creator list caches
     if let Some(ref inv) = state.invalidator {
         let _ = inv.invalidate_pattern("search:creators:*").await;
-        let _ = inv.invalidate_pattern(&keys::http_response_pattern("/creators/")).await;
+        let _ = inv
+            .invalidate_pattern(&keys::http_response_pattern("/creators/"))
+            .await;
     }
 
     // Main branch added Webhook notification
@@ -114,7 +118,9 @@ pub async fn get_creator_by_username(
 
     if let Some(conn) = state.redis.as_ref() {
         let mut conn = conn.clone();
-        if let Some(cached) = redis_client::get::<Creator>(&mut conn, &keys::creator(username)).await {
+        if let Some(cached) =
+            redis_client::get::<Creator>(&mut conn, &keys::creator(username)).await
+        {
             return Ok(Some(cached));
         }
     }

--- a/src/controllers/tip_controller.rs
+++ b/src/controllers/tip_controller.rs
@@ -7,7 +7,9 @@ use crate::db::connection::AppState;
 use crate::db::query_logger::QueryLogger;
 use crate::db::transaction;
 use crate::errors::{AppError, AppResult};
-use crate::metrics::collectors::DB_QUERY_DURATION_SECONDS; // Kept from your branch
+use crate::metrics::collectors::{
+    DB_QUERY_DURATION_SECONDS, TIPS_AMOUNT_XLM, TIPS_CREATED_TOTAL, TIPS_FAILED_TOTAL,
+};
 use crate::models::pagination::{PaginatedResponse, PaginationParams};
 use crate::models::tip::{RecordTipRequest, Tip, TipFilters, TipSortParams};
 use crate::moderation::ContentType;
@@ -22,6 +24,9 @@ pub async fn record_tip(state: &AppState, req: RecordTipRequest) -> AppResult<Ti
                 .check_content(msg, ContentType::TipMessage, None)
                 .await;
             if moderation.has_high_confidence_violation(0.90) {
+                TIPS_FAILED_TOTAL
+                    .with_label_values(&["moderation_rejected"])
+                    .inc();
                 return Err(AppError::Validation(
                     crate::errors::ValidationError::InvalidRequest {
                         message: "Tip message was rejected by content moderation".to_string(),
@@ -37,12 +42,25 @@ pub async fn record_tip(state: &AppState, req: RecordTipRequest) -> AppResult<Ti
 
     let start = Instant::now();
     // Pass state into the internal helper to support WebSocket broadcasting
-    let (tip, match_result) = record_tip_in_tx(state, &mut tx, &req).await?;
+    let (tip, match_result) = match record_tip_in_tx(state, &mut tx, &req).await {
+        Ok(result) => result,
+        Err(e) => {
+            TIPS_FAILED_TOTAL
+                .with_label_values(&["record_tip_in_tx"])
+                .inc();
+            return Err(e);
+        }
+    };
     tx.commit().await?;
     let duration = start.elapsed();
 
-    // Record your Prometheus metric
-    DB_QUERY_DURATION_SECONDS.observe(duration.as_secs_f64());
+    DB_QUERY_DURATION_SECONDS
+        .with_label_values(&["tip_atomic_record"])
+        .observe(duration.as_secs_f64());
+    TIPS_CREATED_TOTAL.inc();
+    if let Ok(amount) = tip.amount.parse::<f64>() {
+        TIPS_AMOUNT_XLM.observe(amount);
+    }
 
     if let Some(match_info) = match_result {
         let db = state.db.clone();
@@ -81,8 +99,12 @@ pub async fn record_tip(state: &AppState, req: RecordTipRequest) -> AppResult<Ti
         let tips_pattern = keys::creator_tips_pattern(&tip.creator_username);
         let _ = inv.invalidate_pattern(&tips_pattern).await;
         let _ = inv.invalidate_pattern("leaderboard:*").await;
-        let _ = inv.invalidate_pattern(&keys::http_response_pattern("/tips")).await;
-        let _ = inv.invalidate_pattern(&keys::http_response_pattern("/creators/")).await;
+        let _ = inv
+            .invalidate_pattern(&keys::http_response_pattern("/tips"))
+            .await;
+        let _ = inv
+            .invalidate_pattern(&keys::http_response_pattern("/creators/"))
+            .await;
     }
 
     // Main branch added Webhooks
@@ -160,7 +182,14 @@ pub async fn record_tip_in_tx(
         .await?;
 
     // Apply team splits if the recipient belongs to a team.
-    team_controller::record_tip_splits(&state, tip.id, &tip.creator_username, &tip.amount, &mut *tx).await?;
+    team_controller::record_tip_splits(
+        &state,
+        tip.id,
+        &tip.creator_username,
+        &tip.amount,
+        &mut *tx,
+    )
+    .await?;
 
     // Broadcast to WebSocket (Main branch feature)
     let event = crate::ws::TipEvent {
@@ -244,8 +273,9 @@ pub async fn get_tips_for_creator(state: &AppState, username: &str) -> AppResult
         .await?;
     let duration = start.elapsed();
 
-    // Record your Prometheus metric
-    DB_QUERY_DURATION_SECONDS.observe(duration.as_secs_f64());
+    DB_QUERY_DURATION_SECONDS
+        .with_label_values(&["tips_list_by_creator"])
+        .observe(duration.as_secs_f64());
 
     QueryLogger::log_query(query, duration);
     state.performance.track_query(query, duration);
@@ -350,7 +380,9 @@ pub async fn get_tips_paginated(
         .await?;
     let duration = start.elapsed();
 
-    DB_QUERY_DURATION_SECONDS.observe(duration.as_secs_f64());
+    DB_QUERY_DURATION_SECONDS
+        .with_label_values(&["tips_paginated"])
+        .observe(duration.as_secs_f64());
 
     Ok(PaginatedResponse::new(tips, total, &params))
 }

--- a/src/cqrs/command_bus.rs
+++ b/src/cqrs/command_bus.rs
@@ -1,84 +1,56 @@
 use super::commands::{Command, CommandResult};
-use crate::controllers::{creator_controller, tip_controller};
 use crate::db::connection::AppState;
 use crate::errors::AppResult;
-use crate::events::{Event, EventStore};
-use crate::models::creator::CreateCreatorRequest;
-use crate::models::tip::RecordTipRequest;
-use chrono::Utc;
 use std::sync::Arc;
+
+use super::handlers::{CommandHandler, RecordTipHandler, RegisterCreatorHandler};
+use super::synchronizer::CqrsSynchronizer;
+use crate::events::EventStore;
 
 /// Executes write-side commands, persists to the write DB, and appends domain events.
 pub struct CommandBus {
-    state: Arc<AppState>,
-    events: Arc<EventStore>,
+    handlers: Vec<Arc<dyn CommandHandler>>,
+    synchronizer: Option<Arc<CqrsSynchronizer>>,
 }
 
 impl CommandBus {
     pub fn new(state: Arc<AppState>, events: Arc<EventStore>) -> Self {
-        Self { state, events }
+        let handlers: Vec<Arc<dyn CommandHandler>> = vec![
+            Arc::new(RegisterCreatorHandler::new(
+                Arc::clone(&state),
+                Arc::clone(&events),
+            )),
+            Arc::new(RecordTipHandler::new(
+                Arc::clone(&state),
+                Arc::clone(&events),
+            )),
+        ];
+        Self {
+            handlers,
+            synchronizer: None,
+        }
+    }
+
+    pub fn with_synchronizer(mut self, synchronizer: Arc<CqrsSynchronizer>) -> Self {
+        self.synchronizer = Some(synchronizer);
+        self
     }
 
     pub async fn execute(&self, cmd: Command) -> AppResult<CommandResult> {
-        match cmd {
-            Command::RegisterCreator {
-                username,
-                wallet_address,
-                email,
-            } => {
-                let creator = creator_controller::create_creator(
-                    &self.state,
-                    CreateCreatorRequest {
-                        username,
-                        wallet_address,
-                        email,
-                    },
-                )
-                .await?;
-
-                let event = Event::CreatorRegistered {
-                    id: creator.id,
-                    username: creator.username.clone(),
-                    wallet_address: creator.wallet_address.clone(),
-                    timestamp: Utc::now(),
-                };
-                let _ = self.events.append(&event).await;
-
-                Ok(CommandResult::CreatorRegistered { id: creator.id })
-            }
-
-            Command::RecordTip {
-                creator_username,
-                amount,
-                transaction_hash,
-            } => {
-                let tip = tip_controller::record_tip(
-                    &self.state,
-                    RecordTipRequest {
-                        username: creator_username,
-                        amount,
-                        transaction_hash,
-                    },
-                )
-                .await?;
-
-                // Resolve creator_id for the event (best-effort; skip on miss).
-                if let Ok(Some(creator)) =
-                    creator_controller::get_creator_by_username(&self.state, &tip.creator_username)
-                        .await
-                {
-                    let event = Event::TipReceived {
-                        id: tip.id,
-                        creator_id: creator.id,
-                        amount: tip.amount.clone(),
-                        transaction_hash: tip.transaction_hash.clone(),
-                        timestamp: Utc::now(),
-                    };
-                    let _ = self.events.append(&event).await;
+        if let Some(handler) = self.handlers.iter().find(|handler| handler.handles(&cmd)) {
+            let handled = handler.handle(cmd).await?;
+            if let Some(result) = handled {
+                if let Some(sync) = &self.synchronizer {
+                    let _ = sync
+                        .sync_with_retry(3, std::time::Duration::from_millis(100))
+                        .await;
                 }
-
-                Ok(CommandResult::TipRecorded { id: tip.id })
+                return Ok(result);
             }
         }
+
+        Err(crate::errors::AppError::internal_with_message(
+            "No command handler registered",
+        ))
     }
 }

--- a/src/cqrs/handlers.rs
+++ b/src/cqrs/handlers.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+
+use crate::controllers::{creator_controller, tip_controller};
+use crate::db::connection::AppState;
+use crate::errors::AppResult;
+use crate::events::{Event, EventStore};
+use crate::models::creator::CreateCreatorRequest;
+use crate::models::tip::RecordTipRequest;
+
+use super::commands::{Command, CommandResult};
+
+#[async_trait]
+pub trait CommandHandler: Send + Sync {
+    fn handles(&self, cmd: &Command) -> bool;
+    async fn handle(&self, cmd: Command) -> AppResult<Option<CommandResult>>;
+}
+
+pub struct RegisterCreatorHandler {
+    state: Arc<AppState>,
+    events: Arc<EventStore>,
+}
+
+impl RegisterCreatorHandler {
+    pub fn new(state: Arc<AppState>, events: Arc<EventStore>) -> Self {
+        Self { state, events }
+    }
+}
+
+#[async_trait]
+impl CommandHandler for RegisterCreatorHandler {
+    fn handles(&self, cmd: &Command) -> bool {
+        matches!(cmd, Command::RegisterCreator { .. })
+    }
+
+    async fn handle(&self, cmd: Command) -> AppResult<Option<CommandResult>> {
+        let Command::RegisterCreator {
+            username,
+            wallet_address,
+            email,
+        } = cmd
+        else {
+            return Ok(None);
+        };
+
+        let creator = creator_controller::create_creator(
+            &self.state,
+            CreateCreatorRequest {
+                username,
+                wallet_address,
+                email,
+            },
+        )
+        .await?;
+
+        let event = Event::CreatorRegistered {
+            id: creator.id,
+            username: creator.username.clone(),
+            wallet_address: creator.wallet_address.clone(),
+            timestamp: Utc::now(),
+        };
+        let _ = self.events.append(&event).await;
+
+        Ok(Some(CommandResult::CreatorRegistered { id: creator.id }))
+    }
+}
+
+pub struct RecordTipHandler {
+    state: Arc<AppState>,
+    events: Arc<EventStore>,
+}
+
+impl RecordTipHandler {
+    pub fn new(state: Arc<AppState>, events: Arc<EventStore>) -> Self {
+        Self { state, events }
+    }
+}
+
+#[async_trait]
+impl CommandHandler for RecordTipHandler {
+    fn handles(&self, cmd: &Command) -> bool {
+        matches!(cmd, Command::RecordTip { .. })
+    }
+
+    async fn handle(&self, cmd: Command) -> AppResult<Option<CommandResult>> {
+        let Command::RecordTip {
+            creator_username,
+            amount,
+            transaction_hash,
+        } = cmd
+        else {
+            return Ok(None);
+        };
+
+        let tip = tip_controller::record_tip(
+            &self.state,
+            RecordTipRequest {
+                username: creator_username,
+                amount,
+                transaction_hash,
+                message: None,
+            },
+        )
+        .await?;
+
+        if let Ok(Some(creator)) =
+            creator_controller::get_creator_by_username(&self.state, &tip.creator_username).await
+        {
+            let event = Event::TipReceived {
+                id: tip.id,
+                creator_id: creator.id,
+                amount: tip.amount.clone(),
+                transaction_hash: tip.transaction_hash.clone(),
+                timestamp: Utc::now(),
+            };
+            let _ = self.events.append(&event).await;
+        }
+
+        Ok(Some(CommandResult::TipRecorded { id: tip.id }))
+    }
+}

--- a/src/cqrs/mod.rs
+++ b/src/cqrs/mod.rs
@@ -1,10 +1,14 @@
 pub mod command_bus;
 pub mod commands;
+pub mod handlers;
 pub mod projections;
 pub mod queries;
 pub mod query_bus;
+pub mod synchronizer;
 
 pub use command_bus::CommandBus;
 pub use commands::{Command, CommandResult};
+pub use projections::{CreatorSummaryView, ProjectionSyncReport};
 pub use queries::{Query, QueryResult};
 pub use query_bus::QueryBus;
+pub use synchronizer::CqrsSynchronizer;

--- a/src/cqrs/projections.rs
+++ b/src/cqrs/projections.rs
@@ -10,6 +10,13 @@ pub struct CqrsProjection {
     events: Arc<EventStore>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ProjectionSyncReport {
+    pub from_sequence: i64,
+    pub to_sequence: i64,
+    pub processed_events: usize,
+}
+
 impl CqrsProjection {
     pub fn new(read_db: PgPool, events: Arc<EventStore>) -> Self {
         Self { read_db, events }
@@ -60,4 +67,52 @@ impl CqrsProjection {
         }
         Ok(())
     }
+
+    /// Incrementally apply events from a sequence number.
+    /// Used by the CQRS synchronizer to provide eventual consistency.
+    pub async fn sync_from_sequence(&self, from_sequence: i64) -> AppResult<ProjectionSyncReport> {
+        let events = self.events.replay_from(from_sequence).await?;
+        let mut processed = 0usize;
+        for event in &events {
+            self.sync_event(event).await?;
+            processed += 1;
+        }
+
+        let to_sequence = if processed == 0 {
+            from_sequence - 1
+        } else {
+            from_sequence + processed as i64 - 1
+        };
+
+        Ok(ProjectionSyncReport {
+            from_sequence,
+            to_sequence,
+            processed_events: processed,
+        })
+    }
+
+    /// Read-optimized view query for command/query separation.
+    pub async fn get_creator_summary_by_username(
+        &self,
+        username: &str,
+    ) -> AppResult<Option<CreatorSummaryView>> {
+        let row = sqlx::query_as::<_, CreatorSummaryView>(
+            "SELECT id, username, wallet_address, tip_count, registered_at
+             FROM creator_read_model
+             WHERE username = $1",
+        )
+        .bind(username)
+        .fetch_optional(&self.read_db)
+        .await?;
+        Ok(row)
+    }
+}
+
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize, serde::Deserialize)]
+pub struct CreatorSummaryView {
+    pub id: uuid::Uuid,
+    pub username: String,
+    pub wallet_address: String,
+    pub tip_count: i64,
+    pub registered_at: chrono::DateTime<chrono::Utc>,
 }

--- a/src/cqrs/queries.rs
+++ b/src/cqrs/queries.rs
@@ -2,6 +2,8 @@ use crate::models::pagination::{PaginatedResponse, PaginationParams};
 use crate::models::{creator::Creator, tip::Tip};
 use uuid::Uuid;
 
+use super::projections::CreatorSummaryView;
+
 /// All read-side intents in the system.
 #[derive(Debug)]
 pub enum Query {
@@ -15,6 +17,9 @@ pub enum Query {
     GetCreatorTipCount {
         creator_id: Uuid,
     },
+    GetCreatorSummary {
+        username: String,
+    },
 }
 
 /// The result of executing a query.
@@ -23,4 +28,5 @@ pub enum QueryResult {
     Creator(Option<Creator>),
     Tips(PaginatedResponse<Tip>),
     TipCount(i64),
+    CreatorSummary(Option<CreatorSummaryView>),
 }

--- a/src/cqrs/query_bus.rs
+++ b/src/cqrs/query_bus.rs
@@ -4,17 +4,30 @@ use crate::db::connection::AppState;
 use crate::errors::AppResult;
 use std::sync::Arc;
 
+use super::projections::CqrsProjection;
+
 /// Executes read-side queries against the (optionally separate) read pool.
 ///
 /// In this deployment both read and write share the same `AppState` pool.
 /// To point reads at a replica, swap `state.db` for a replica `PgPool` here.
 pub struct QueryBus {
     state: Arc<AppState>,
+    projection: Option<Arc<CqrsProjection>>,
 }
 
 impl QueryBus {
     pub fn new(state: Arc<AppState>) -> Self {
-        Self { state }
+        Self {
+            state,
+            projection: None,
+        }
+    }
+
+    pub fn with_projection(state: Arc<AppState>, projection: Arc<CqrsProjection>) -> Self {
+        Self {
+            state,
+            projection: Some(projection),
+        }
     }
 
     pub async fn execute(&self, query: Query) -> AppResult<QueryResult> {
@@ -41,6 +54,16 @@ impl QueryBus {
                 .fetch_one(&self.state.db)
                 .await?;
                 Ok(QueryResult::TipCount(count))
+            }
+            Query::GetCreatorSummary { username } => {
+                if let Some(projection) = &self.projection {
+                    let summary = projection
+                        .get_creator_summary_by_username(&username)
+                        .await?;
+                    Ok(QueryResult::CreatorSummary(summary))
+                } else {
+                    Ok(QueryResult::CreatorSummary(None))
+                }
             }
         }
     }

--- a/src/cqrs/synchronizer.rs
+++ b/src/cqrs/synchronizer.rs
@@ -1,0 +1,63 @@
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::time::sleep;
+
+use crate::errors::AppResult;
+
+use super::projections::{CqrsProjection, ProjectionSyncReport};
+
+#[derive(Clone)]
+pub struct CqrsSynchronizer {
+    projection: Arc<CqrsProjection>,
+    last_sequence: Arc<AtomicI64>,
+}
+
+impl CqrsSynchronizer {
+    pub fn new(projection: Arc<CqrsProjection>) -> Self {
+        Self {
+            projection,
+            last_sequence: Arc::new(AtomicI64::new(0)),
+        }
+    }
+
+    pub fn last_sequence(&self) -> i64 {
+        self.last_sequence.load(Ordering::SeqCst)
+    }
+
+    pub async fn sync_once(&self) -> AppResult<ProjectionSyncReport> {
+        let from = self.last_sequence();
+        let report = self.projection.sync_from_sequence(from + 1).await?;
+        if report.to_sequence > 0 {
+            self.last_sequence
+                .store(report.to_sequence, Ordering::SeqCst);
+        }
+        Ok(report)
+    }
+
+    /// Best-effort eventual consistency loop for read-model catch-up.
+    pub async fn sync_with_retry(
+        &self,
+        max_attempts: usize,
+        base_delay: Duration,
+    ) -> AppResult<ProjectionSyncReport> {
+        let mut attempts = 0usize;
+        loop {
+            attempts += 1;
+            match self.sync_once().await {
+                Ok(report) => return Ok(report),
+                Err(e) if attempts < max_attempts => {
+                    tracing::warn!(
+                        attempt = attempts,
+                        max_attempts,
+                        error = %e,
+                        "CQRS read-model sync failed, retrying"
+                    );
+                    sleep(base_delay.saturating_mul(attempts as u32)).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}

--- a/src/mocking/generators.rs
+++ b/src/mocking/generators.rs
@@ -1,0 +1,47 @@
+use rand::distributions::{Alphanumeric, DistString};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Deterministic-friendly random string generator for mock payloads.
+pub fn random_token(len: usize) -> String {
+    Alphanumeric.sample_string(&mut rand::thread_rng(), len)
+}
+
+pub fn random_uuid() -> String {
+    Uuid::new_v4().to_string()
+}
+
+pub fn random_email(prefix: &str) -> String {
+    format!("{}{}@example.test", prefix, random_token(8).to_lowercase())
+}
+
+pub fn random_wallet_address() -> String {
+    format!("G{}", random_token(55))
+}
+
+pub fn random_tx_hash() -> String {
+    random_token(64)
+}
+
+pub fn creator_payload(username: Option<&str>) -> serde_json::Value {
+    let name = username
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("creator_{}", random_token(6).to_lowercase()));
+    json!({
+        "id": random_uuid(),
+        "username": name,
+        "wallet_address": random_wallet_address(),
+        "email": random_email("creator_"),
+        "created_at": chrono::Utc::now(),
+    })
+}
+
+pub fn tip_payload(username: Option<&str>, amount: Option<&str>) -> serde_json::Value {
+    json!({
+        "id": random_uuid(),
+        "creator_username": username.unwrap_or("creator_demo"),
+        "amount": amount.unwrap_or("5.00"),
+        "transaction_hash": random_tx_hash(),
+        "created_at": chrono::Utc::now(),
+    })
+}

--- a/src/mocking/mod.rs
+++ b/src/mocking/mod.rs
@@ -1,6 +1,9 @@
+pub mod generators;
 pub mod recorder;
 pub mod registry;
+pub mod server;
 pub mod templates;
 
 pub use recorder::MockRecorder;
 pub use registry::{MockEntry, MockRegistry, MockRequest, MockResponse};
+pub use server::{MockServer, MockServerRequest};

--- a/src/mocking/recorder.rs
+++ b/src/mocking/recorder.rs
@@ -4,6 +4,8 @@ use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use super::registry::{MockRequest, MockResponse};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecordedInteraction {
     pub id: String,
@@ -30,11 +32,13 @@ impl MockRecorder {
     }
 
     pub fn enable(&self) {
-        self.enabled.store(true, std::sync::atomic::Ordering::SeqCst);
+        self.enabled
+            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     pub fn disable(&self) {
-        self.enabled.store(false, std::sync::atomic::Ordering::SeqCst);
+        self.enabled
+            .store(false, std::sync::atomic::Ordering::SeqCst);
     }
 
     pub fn is_enabled(&self) -> bool {
@@ -70,6 +74,39 @@ impl MockRecorder {
 
     pub async fn clear(&self) {
         self.interactions.write().await.clear();
+    }
+
+    pub async fn export_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(&self.get_all().await)
+    }
+
+    pub async fn import_json(&self, payload: &str) -> Result<usize, serde_json::Error> {
+        let imported: Vec<RecordedInteraction> = serde_json::from_str(payload)?;
+        let count = imported.len();
+        self.interactions.write().await.extend(imported);
+        Ok(count)
+    }
+
+    /// Convert recorded interactions to registerable mock entries for replay.
+    pub async fn as_mock_entries(&self) -> Vec<(MockRequest, MockResponse)> {
+        self.get_all()
+            .await
+            .into_iter()
+            .map(|r| {
+                (
+                    MockRequest {
+                        method: r.method,
+                        path: r.path,
+                        body_contains: r.request_body,
+                    },
+                    MockResponse {
+                        status: r.response_status,
+                        body: r.response_body,
+                        headers: Default::default(),
+                    },
+                )
+            })
+            .collect()
     }
 }
 

--- a/src/mocking/registry.rs
+++ b/src/mocking/registry.rs
@@ -66,14 +66,45 @@ impl MockRegistry {
         path: &str,
         body: Option<&Value>,
     ) -> Option<MockResponse> {
+        self.match_http_request(method, path, body, None).await
+    }
+
+    /// Match request using method, path, body, and optional headers.
+    /// Path supports:
+    /// - exact matches
+    /// - wildcard segments, e.g. `/creators/*/tips`
+    /// - path params, e.g. `/creators/:username/tips`
+    /// Query constraints can be included in the registered path:
+    /// `/tips?status=settled&network=testnet`.
+    pub async fn match_http_request(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<&Value>,
+        headers: Option<&HashMap<String, String>>,
+    ) -> Option<MockResponse> {
+        self.match_http_request_with_context(method, path, body, headers)
+            .await
+            .map(|(response, _)| response)
+    }
+
+    pub async fn match_http_request_with_context(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<&Value>,
+        headers: Option<&HashMap<String, String>>,
+    ) -> Option<(MockResponse, HashMap<String, String>)> {
         let mut entries = self.entries.write().await;
         for entry in entries.iter_mut() {
             if entry.request.method.eq_ignore_ascii_case(method)
-                && entry.request.path == path
+                && path_matches(&entry.request.path, path)
                 && body_matches(body, entry.request.body_contains.as_ref())
+                && headers_match(headers, &entry.response.headers)
             {
                 entry.hit_count += 1;
-                return Some(entry.response.clone());
+                let params = extract_path_params(&entry.request.path, path);
+                return Some((entry.response.clone(), params));
             }
         }
         None
@@ -99,11 +130,117 @@ fn body_matches(actual: Option<&Value>, pattern: Option<&Value>) -> bool {
     }
 }
 
+/// Header matching is opt-in. We match only `x-mock-match-*` response headers as
+/// constraints so existing tests and fixtures remain backwards compatible.
+fn headers_match(
+    actual: Option<&HashMap<String, String>>,
+    response_headers: &HashMap<String, String>,
+) -> bool {
+    let Some(actual) = actual else {
+        return !response_headers
+            .keys()
+            .any(|k| k.to_ascii_lowercase().starts_with("x-mock-match-"));
+    };
+
+    response_headers
+        .iter()
+        .filter_map(|(k, v)| {
+            let lower = k.to_ascii_lowercase();
+            lower
+                .strip_prefix("x-mock-match-")
+                .map(|header_name| (header_name.to_string(), v))
+        })
+        .all(|(header_name, expected)| {
+            actual
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case(&header_name))
+                .map(|(_, v)| v == expected)
+                .unwrap_or(false)
+        })
+}
+
+fn path_matches(registered: &str, incoming: &str) -> bool {
+    let (registered_path, registered_query) = split_path_query(registered);
+    let (incoming_path, incoming_query) = split_path_query(incoming);
+
+    segment_match(&registered_path, &incoming_path)
+        && query_subset_match(&registered_query, &incoming_query)
+}
+
+fn split_path_query(input: &str) -> (String, HashMap<String, String>) {
+    let mut parts = input.splitn(2, '?');
+    let path = parts.next().unwrap_or_default().to_string();
+    let query = parts
+        .next()
+        .map(parse_query_string)
+        .unwrap_or_else(HashMap::new);
+    (path, query)
+}
+
+fn parse_query_string(raw: &str) -> HashMap<String, String> {
+    raw.split('&')
+        .filter(|pair| !pair.is_empty())
+        .filter_map(|pair| {
+            let mut parts = pair.splitn(2, '=');
+            let k = parts.next()?.trim();
+            let v = parts.next().unwrap_or("").trim();
+            if k.is_empty() {
+                None
+            } else {
+                Some((k.to_string(), v.to_string()))
+            }
+        })
+        .collect()
+}
+
+fn query_subset_match(
+    expected: &HashMap<String, String>,
+    incoming: &HashMap<String, String>,
+) -> bool {
+    expected
+        .iter()
+        .all(|(k, v)| incoming.get(k).map(|iv| iv == v).unwrap_or(false))
+}
+
+fn segment_match(expected_path: &str, incoming_path: &str) -> bool {
+    let expected = normalize_path_segments(expected_path);
+    let incoming = normalize_path_segments(incoming_path);
+
+    if expected.len() != incoming.len() {
+        return false;
+    }
+
+    expected
+        .iter()
+        .zip(incoming.iter())
+        .all(|(e, i)| e == "*" || e.starts_with(':') || e == i)
+}
+
+fn normalize_path_segments(path: &str) -> Vec<String> {
+    path.split('/')
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn extract_path_params(expected_path: &str, incoming_path: &str) -> HashMap<String, String> {
+    let expected = normalize_path_segments(expected_path);
+    let incoming = normalize_path_segments(incoming_path);
+    let mut params = HashMap::new();
+
+    for (e, i) in expected.iter().zip(incoming.iter()) {
+        if let Some(name) = e.strip_prefix(':') {
+            params.insert(format!("request.path_param.{name}"), i.clone());
+        }
+    }
+    params
+}
+
 fn json_subset(actual: &Value, pattern: &Value) -> bool {
     match (actual, pattern) {
-        (Value::Object(a), Value::Object(p)) => {
-            p.iter().all(|(k, v)| a.get(k).map_or(false, |av| json_subset(av, v)))
-        }
+        (Value::Object(a), Value::Object(p)) => p
+            .iter()
+            .all(|(k, v)| a.get(k).map_or(false, |av| json_subset(av, v))),
         _ => actual == pattern,
     }
 }

--- a/src/mocking/server.rs
+++ b/src/mocking/server.rs
@@ -1,0 +1,205 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::Bytes;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::routing::{any, delete, get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use super::recorder::MockRecorder;
+use super::registry::{MockRegistry, MockRequest, MockResponse};
+use super::templates::render_response_template;
+
+#[derive(Clone)]
+pub struct MockServer {
+    pub registry: MockRegistry,
+    pub recorder: MockRecorder,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MockServerRequest {
+    pub method: String,
+    pub path: String,
+    pub headers: HashMap<String, String>,
+    pub body: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterMockRequest {
+    pub request: MockRequest,
+    pub response: MockResponse,
+}
+
+impl MockServer {
+    pub fn new() -> Self {
+        Self {
+            registry: MockRegistry::new(),
+            recorder: MockRecorder::new(),
+        }
+    }
+
+    pub fn router(self: Arc<Self>) -> Router {
+        Router::new()
+            .route("/_mock/entries", post(register).get(list).delete(clear))
+            .route("/_mock/entries/:id", delete(remove))
+            .route("/_mock/recording/enable", post(enable_recording))
+            .route("/_mock/recording/disable", post(disable_recording))
+            .route("/_mock/recording", get(recordings).delete(clear_recordings))
+            .route("/_mock/replay", post(replay_recordings))
+            .route("/{*path}", any(handle))
+            .with_state(self)
+    }
+
+    pub async fn handle_request(&self, req: MockServerRequest) -> MockResponse {
+        let request_path = req.path.clone();
+        let request_body = req.body.clone();
+
+        let Some((response, path_params)) = self
+            .registry
+            .match_http_request_with_context(
+                &req.method,
+                &request_path,
+                request_body.as_ref(),
+                Some(&req.headers),
+            )
+            .await
+        else {
+            let body = json!({
+                "error": "no mock matched request",
+                "method": req.method,
+                "path": request_path
+            });
+            return MockResponse {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body,
+                headers: HashMap::new(),
+            };
+        };
+
+        let rendered =
+            render_response_template(&response.body, &req.method, &req.path, &path_params);
+
+        let final_response = MockResponse {
+            status: response.status,
+            body: rendered,
+            headers: response.headers.clone(),
+        };
+
+        self.recorder
+            .record(
+                &req.method,
+                &request_path,
+                request_body,
+                final_response.status,
+                final_response.body.clone(),
+            )
+            .await;
+
+        final_response
+    }
+}
+
+impl Default for MockServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+async fn register(
+    State(server): State<Arc<MockServer>>,
+    Json(payload): Json<RegisterMockRequest>,
+) -> Json<Value> {
+    let id = server
+        .registry
+        .register(payload.request, payload.response)
+        .await;
+    Json(json!({ "id": id }))
+}
+
+async fn list(State(server): State<Arc<MockServer>>) -> Json<Vec<super::registry::MockEntry>> {
+    Json(server.registry.list().await)
+}
+
+async fn remove(State(server): State<Arc<MockServer>>, Path(id): Path<String>) -> StatusCode {
+    server.registry.remove(&id).await;
+    StatusCode::NO_CONTENT
+}
+
+async fn clear(State(server): State<Arc<MockServer>>) -> StatusCode {
+    server.registry.clear().await;
+    StatusCode::NO_CONTENT
+}
+
+async fn enable_recording(State(server): State<Arc<MockServer>>) -> StatusCode {
+    server.recorder.enable();
+    StatusCode::NO_CONTENT
+}
+
+async fn disable_recording(State(server): State<Arc<MockServer>>) -> StatusCode {
+    server.recorder.disable();
+    StatusCode::NO_CONTENT
+}
+
+async fn recordings(
+    State(server): State<Arc<MockServer>>,
+) -> Json<Vec<super::recorder::RecordedInteraction>> {
+    Json(server.recorder.get_all().await)
+}
+
+async fn clear_recordings(State(server): State<Arc<MockServer>>) -> StatusCode {
+    server.recorder.clear().await;
+    StatusCode::NO_CONTENT
+}
+
+async fn replay_recordings(State(server): State<Arc<MockServer>>) -> Json<Value> {
+    let entries = server.recorder.as_mock_entries().await;
+    let mut restored = 0usize;
+    for (req, res) in entries {
+        server.registry.register(req, res).await;
+        restored += 1;
+    }
+    Json(json!({ "restored": restored }))
+}
+
+async fn handle(
+    State(server): State<Arc<MockServer>>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> (StatusCode, Json<Value>) {
+    let headers = headers
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|sv| (k.as_str().to_string(), sv.to_string()))
+        })
+        .collect::<HashMap<_, _>>();
+
+    let body_json = if body.is_empty() {
+        None
+    } else {
+        serde_json::from_slice::<Value>(&body).ok()
+    };
+
+    let request = MockServerRequest {
+        method: method.to_string(),
+        path: uri
+            .path_and_query()
+            .map(|p| p.as_str().to_string())
+            .unwrap_or_else(|| uri.path().to_string()),
+        headers,
+        body: body_json,
+    };
+
+    let matched = server.handle_request(request).await;
+
+    (
+        StatusCode::from_u16(matched.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+        Json(matched.body),
+    )
+}

--- a/src/mocking/templates.rs
+++ b/src/mocking/templates.rs
@@ -1,6 +1,8 @@
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use crate::mocking::generators;
+
 pub fn creator_template(username: &str, wallet: &str) -> Value {
     json!({
         "id": Uuid::new_v4(),
@@ -37,4 +39,63 @@ pub fn stellar_transaction_template(tx_hash: &str, successful: bool) -> Value {
 
 pub fn error_template(status: u16, message: &str) -> Value {
     json!({ "error": message, "status": status })
+}
+
+/// Render template placeholders in a JSON value.
+///
+/// Supported placeholders:
+/// - `{{request.path}}`
+/// - `{{request.method}}`
+/// - `{{random.uuid}}`
+/// - `{{random.email}}`
+/// - `{{random.wallet}}`
+/// - `{{random.tx_hash}}`
+/// - `{{now.rfc3339}}`
+pub fn render_response_template(
+    template: &Value,
+    method: &str,
+    path: &str,
+    replacements: &std::collections::HashMap<String, String>,
+) -> Value {
+    match template {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        render_response_template(v, method, path, replacements),
+                    )
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|v| render_response_template(v, method, path, replacements))
+                .collect(),
+        ),
+        Value::String(s) => Value::String(render_template_string(s, method, path, replacements)),
+        _ => template.clone(),
+    }
+}
+
+fn render_template_string(
+    input: &str,
+    method: &str,
+    path: &str,
+    replacements: &std::collections::HashMap<String, String>,
+) -> String {
+    let mut out = input.to_string();
+    out = out.replace("{{request.method}}", method);
+    out = out.replace("{{request.path}}", path);
+    out = out.replace("{{random.uuid}}", &generators::random_uuid());
+    out = out.replace("{{random.email}}", &generators::random_email("mock_"));
+    out = out.replace("{{random.wallet}}", &generators::random_wallet_address());
+    out = out.replace("{{random.tx_hash}}", &generators::random_tx_hash());
+    out = out.replace("{{now.rfc3339}}", &chrono::Utc::now().to_rfc3339());
+
+    for (k, v) in replacements {
+        out = out.replace(&format!("{{{{{k}}}}}"), v);
+    }
+    out
 }

--- a/src/saga/compensation.rs
+++ b/src/saga/compensation.rs
@@ -1,15 +1,38 @@
+use super::workflow::{SagaStepStatus, SagaWorkflow};
 use crate::errors::AppError;
 use sqlx::PgPool;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use uuid::Uuid;
-use super::workflow::{SagaWorkflow, SagaStepStatus};
+
+type CompensationFuture = Pin<Box<dyn Future<Output = Result<(), AppError>> + Send>>;
+type CompensationFn = Arc<dyn Fn() -> CompensationFuture + Send + Sync>;
 
 pub struct CompensationHandler {
     pool: PgPool,
+    hooks: Arc<RwLock<HashMap<String, CompensationFn>>>,
 }
 
 impl CompensationHandler {
     pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            hooks: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn register_hook<F, Fut>(&self, name: impl Into<String>, hook: F)
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<(), AppError>> + Send + 'static,
+    {
+        self.hooks
+            .write()
+            .await
+            .insert(name.into(), Arc::new(move || Box::pin(hook())));
     }
 
     pub async fn compensate_workflow(&self, workflow: &mut SagaWorkflow) -> Result<(), AppError> {
@@ -35,17 +58,19 @@ impl CompensationHandler {
     }
 
     async fn execute_compensation(&self, compensation: &str) -> Result<(), AppError> {
-        // Parse and execute compensation logic
-        // This is a placeholder for actual compensation execution
-        sqlx::query("SELECT 1")
-            .execute(&self.pool)
-            .await?;
+        if let Some(hook) = self.hooks.read().await.get(compensation).cloned() {
+            return hook().await;
+        }
+
+        // Default to no-op SQL heartbeat so workflow remains recoverable without
+        // explicit compensation hooks registered.
+        sqlx::query("SELECT 1").execute(&self.pool).await?;
         Ok(())
     }
 
     pub async fn save_workflow_state(&self, workflow: &SagaWorkflow) -> Result<(), AppError> {
         let workflow_json = serde_json::to_string(workflow)?;
-        
+
         sqlx::query(
             "INSERT INTO saga_workflows (id, name, state, status, created_at, updated_at)
              VALUES ($1, $2, $3, $4, $5, $6)

--- a/src/saga/mod.rs
+++ b/src/saga/mod.rs
@@ -1,11 +1,10 @@
 pub mod compensation;
+pub mod monitoring;
 pub mod orchestrator;
 pub mod step;
 pub mod tip_saga;
 pub mod workflow;
-pub mod compensation;
-pub mod monitoring;
 
-pub use workflow::{SagaWorkflow, SagaStep, SagaStepStatus};
 pub use compensation::CompensationHandler;
 pub use monitoring::SagaMonitor;
+pub use workflow::{SagaStep, SagaStepStatus, SagaWorkflow};

--- a/src/saga/monitoring.rs
+++ b/src/saga/monitoring.rs
@@ -1,7 +1,7 @@
+use super::workflow::{SagaStepStatus, SagaWorkflow};
 use crate::errors::AppError;
 use sqlx::PgPool;
 use uuid::Uuid;
-use super::workflow::{SagaWorkflow, SagaStepStatus};
 
 pub struct SagaMonitor {
     pool: PgPool,
@@ -69,6 +69,18 @@ impl SagaMonitor {
 
         Ok(workflows)
     }
+
+    pub async fn get_status_counts(&self) -> Result<Vec<SagaStatusCount>, AppError> {
+        let rows = sqlx::query_as::<_, SagaStatusCount>(
+            "SELECT status, COUNT(*)::BIGINT AS total
+             FROM saga_workflows
+             GROUP BY status
+             ORDER BY total DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
 }
 
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -88,4 +100,10 @@ pub struct FailedWorkflow {
     pub status: String,
     pub error_message: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct SagaStatusCount {
+    pub status: String,
+    pub total: i64,
 }

--- a/src/saga/orchestrator.rs
+++ b/src/saga/orchestrator.rs
@@ -1,7 +1,7 @@
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use super::step::{CompensationAction, SagaAction, SagaContext, SagaStep, StepState};
+use super::step::{SagaContext, SagaStep, StepState};
 use crate::errors::{AppError, AppResult};
 
 pub struct SagaOrchestrator {
@@ -25,21 +25,56 @@ impl SagaOrchestrator {
         self.persist_saga(saga_id, saga_type).await?;
 
         for (i, step) in steps.iter().enumerate() {
-            match step.action.execute(&mut ctx).await {
-                Ok(()) => {
-                    self.log_step(saga_id, i, step.name, StepState::Completed, None)
-                        .await?;
-                    self.update_saga_step(saga_id, i).await?;
+            let mut attempts = 0u32;
+            let mut completed = false;
+            let mut last_error = None;
+
+            while attempts <= step.max_retries {
+                attempts += 1;
+                match step.action.execute(&mut ctx).await {
+                    Ok(()) => {
+                        completed = true;
+                        self.log_step(saga_id, i, step.name, StepState::Completed, None)
+                            .await?;
+                        self.update_saga_step(saga_id, i).await?;
+                        break;
+                    }
+                    Err(e) => {
+                        let msg = e.to_string();
+                        last_error = Some(msg.clone());
+                        tracing::warn!(
+                            saga_id = %saga_id,
+                            step = step.name,
+                            attempt = attempts,
+                            max_retries = step.max_retries,
+                            error = %msg,
+                            "Saga step execution failed"
+                        );
+
+                        if attempts <= step.max_retries {
+                            if step.retry_backoff_ms > 0 {
+                                tokio::time::sleep(std::time::Duration::from_millis(
+                                    step.retry_backoff_ms * attempts as u64,
+                                ))
+                                .await;
+                            }
+                            continue;
+                        }
+                    }
                 }
-                Err(e) => {
-                    let msg = e.to_string();
-                    tracing::error!(saga_id = %saga_id, step = step.name, error = %msg, "Saga step failed");
-                    self.log_step(saga_id, i, step.name, StepState::Failed, Some(&msg))
-                        .await?;
-                    self.compensate(saga_id, &steps[..i], &ctx).await;
-                    self.update_saga_state(saga_id, "compensated").await?;
-                    return Err(AppError::internal());
-                }
+            }
+
+            if !completed {
+                let message = last_error.unwrap_or_else(|| "unknown saga step error".to_string());
+                self.log_step(saga_id, i, step.name, StepState::Failed, Some(&message))
+                    .await?;
+                self.update_saga_state(saga_id, "failed").await?;
+                self.compensate(saga_id, &steps[..i], &ctx).await;
+                self.update_saga_state(saga_id, "compensated").await?;
+                return Err(AppError::internal_with_message(format!(
+                    "Saga step `{}` failed: {}",
+                    step.name, message
+                )));
             }
         }
 

--- a/src/saga/step.rs
+++ b/src/saga/step.rs
@@ -53,6 +53,8 @@ pub struct SagaStep {
     pub name: &'static str,
     pub action: Box<dyn SagaAction>,
     pub compensation: Box<dyn CompensationAction>,
+    pub max_retries: u32,
+    pub retry_backoff_ms: u64,
 }
 
 #[async_trait::async_trait]

--- a/src/saga/tip_saga.rs
+++ b/src/saga/tip_saga.rs
@@ -43,6 +43,7 @@ impl SagaAction for RecordTipStep {
                 username: self.req.username.clone(),
                 amount: self.req.amount.clone(),
                 transaction_hash: self.req.transaction_hash.clone(),
+                message: self.req.message.clone(),
             },
         )
         .await?;
@@ -106,6 +107,8 @@ pub async fn run_tip_saga(state: Arc<AppState>, req: RecordTipRequest) -> AppRes
                 tx_hash: req.transaction_hash.clone(),
             }),
             compensation: Box::new(NoOpCompensation),
+            max_retries: 2,
+            retry_backoff_ms: 200,
         },
         SagaStep {
             name: "record_tip",
@@ -121,6 +124,8 @@ pub async fn run_tip_saga(state: Arc<AppState>, req: RecordTipRequest) -> AppRes
             compensation: Box::new(DeleteTipCompensation {
                 pool: state.db.clone(),
             }),
+            max_retries: 1,
+            retry_backoff_ms: 200,
         },
         SagaStep {
             name: "notify",
@@ -130,6 +135,8 @@ pub async fn run_tip_saga(state: Arc<AppState>, req: RecordTipRequest) -> AppRes
                 amount: req.amount.clone(),
             }),
             compensation: Box::new(NoOpCompensation),
+            max_retries: 0,
+            retry_backoff_ms: 0,
         },
     ];
 

--- a/tests/feature_tests.rs
+++ b/tests/feature_tests.rs
@@ -4,12 +4,13 @@ use std::sync::Arc;
 // ── Issue 1: API Mocking ──────────────────────────────────────────────────────
 
 mod api_mocking {
+    use serde_json::json;
     use stellar_tipjar_backend::mocking::{
         recorder::MockRecorder,
         registry::{MockRegistry, MockRequest, MockResponse},
+        server::{MockServer, MockServerRequest},
         templates,
     };
-    use serde_json::json;
 
     #[tokio::test]
     async fn registry_matches_exact_path_and_method() {
@@ -97,7 +98,13 @@ mod api_mocking {
         let recorder = MockRecorder::new();
         recorder.enable();
         recorder
-            .record("POST", "/tips", Some(json!({ "amount": "1.0" })), 201, json!({}))
+            .record(
+                "POST",
+                "/tips",
+                Some(json!({ "amount": "1.0" })),
+                201,
+                json!({}),
+            )
             .await;
         let all = recorder.get_all().await;
         assert_eq!(all.len(), 1);
@@ -117,7 +124,9 @@ mod api_mocking {
     async fn recorder_clear_removes_all() {
         let recorder = MockRecorder::new();
         recorder.enable();
-        recorder.record("GET", "/health", None, 200, json!({})).await;
+        recorder
+            .record("GET", "/health", None, 200, json!({}))
+            .await;
         recorder.clear().await;
         assert!(recorder.get_all().await.is_empty());
     }
@@ -132,6 +141,87 @@ mod api_mocking {
 
         let tx = templates::stellar_transaction_template("txabc", true);
         assert_eq!(tx["successful"], true);
+    }
+
+    #[tokio::test]
+    async fn registry_matches_wildcard_and_query() {
+        let registry = MockRegistry::new();
+        let req = MockRequest {
+            method: "GET".into(),
+            path: "/creators/*/tips?status=settled".into(),
+            body_contains: None,
+        };
+        let resp = MockResponse {
+            status: 200,
+            body: json!({ "ok": true }),
+            headers: Default::default(),
+        };
+        registry.register(req, resp).await;
+
+        let matched = registry
+            .match_request("GET", "/creators/alice/tips?status=settled", None)
+            .await;
+        assert!(matched.is_some());
+    }
+
+    #[tokio::test]
+    async fn server_renders_path_param_templates() {
+        let server = MockServer::new();
+        server
+            .registry
+            .register(
+                MockRequest {
+                    method: "GET".into(),
+                    path: "/creators/:username".into(),
+                    body_contains: None,
+                },
+                MockResponse {
+                    status: 200,
+                    body: json!({
+                        "username": "{{request.path_param.username}}",
+                        "trace": "{{request.method}} {{request.path}}",
+                        "generated_id": "{{random.uuid}}",
+                    }),
+                    headers: Default::default(),
+                },
+            )
+            .await;
+
+        let response = server
+            .handle_request(MockServerRequest {
+                method: "GET".into(),
+                path: "/creators/alice".into(),
+                headers: Default::default(),
+                body: None,
+            })
+            .await;
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body["username"], "alice");
+        assert_eq!(response.body["trace"], "GET /creators/alice");
+        assert!(response.body["generated_id"].as_str().unwrap().len() > 10);
+    }
+
+    #[tokio::test]
+    async fn recorder_can_export_and_import() {
+        let recorder = MockRecorder::new();
+        recorder.enable();
+        recorder
+            .record(
+                "POST",
+                "/tips",
+                Some(json!({ "amount": "3.5" })),
+                201,
+                json!({ "ok": true }),
+            )
+            .await;
+
+        let exported = recorder.export_json().await.unwrap();
+        let imported = MockRecorder::new();
+        let count = imported.import_json(&exported).await.unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(imported.get_all().await.len(), 1);
     }
 }
 
@@ -325,8 +415,8 @@ mod cdn_integration {
 // ── Issue 4: API Deprecation Strategy ────────────────────────────────────────
 
 mod api_deprecation {
-    use stellar_tipjar_backend::middleware::deprecation::DeprecationTracker;
     use std::sync::Arc;
+    use stellar_tipjar_backend::middleware::deprecation::DeprecationTracker;
 
     #[tokio::test]
     async fn tracker_records_hits_per_path() {


### PR DESCRIPTION
## Summary

This PR implements four platform capabilities across testing, architecture, distributed workflows, and observability:

1. API mocking infrastructure for integration tests and local development.
2. CQRS improvements with explicit command handlers and read-model synchronization.
3. Saga orchestration hardening for distributed transactions.
4. Real-time metrics dashboard improvements with Prometheus recording rules and Grafana aggregation.

## What Changed

### #240 API Mocking for Testing
- Added a dedicated mock server engine with runtime registration and replay:
  - `src/mocking/server.rs`
- Added mock data generators for creators, tips, tx hashes, IDs, emails:
  - `src/mocking/generators.rs`
- Upgraded request matching:
  - wildcard/path-param matching (`*`, `:param`)
  - query subset matching
  - optional header constraints via `x-mock-match-*`
- Added response template rendering:
  - request-aware placeholders (`{{request.method}}`, `{{request.path}}`, path params)
  - dynamic data placeholders (`{{random.uuid}}`, `{{random.tx_hash}}`, etc.)
- Extended mock recording:
  - JSON export/import
  - replay into registry as mock entries
- Added/extended tests in `tests/feature_tests.rs`.

### #229 CQRS Pattern
- Added explicit command handler abstraction and concrete handlers:
  - `src/cqrs/handlers.rs`
- Refactored command dispatch to use handler registry:
  - `src/cqrs/command_bus.rs`
- Added read-model sync report + incremental synchronization:
  - `src/cqrs/projections.rs`
  - `src/cqrs/synchronizer.rs`
- Added read-optimized `CreatorSummaryView` query path:
  - `src/cqrs/queries.rs`
  - `src/cqrs/query_bus.rs`
- Exported new CQRS primitives in `src/cqrs/mod.rs`.

### #234 Saga Pattern for Distributed Transactions
- Added saga step retry controls (`max_retries`, `retry_backoff_ms`):
  - `src/saga/step.rs`
- Updated tip saga to define retry/compensation behavior per step:
  - `src/saga/tip_saga.rs`
- Enhanced orchestrator:
  - step retry loop
  - explicit failed/compensated state transitions
  - partial-failure compensation execution in reverse order
  - improved failure reason propagation
  - `src/saga/orchestrator.rs`
- Improved compensation handler with pluggable compensation hooks:
  - `src/saga/compensation.rs`
- Added status aggregation query in saga monitoring:
  - `src/saga/monitoring.rs`
- Cleaned duplicate saga module declaration:
  - `src/saga/mod.rs`

### #236 Real-time Metrics Dashboard
- Added business metric instrumentation in write paths:
  - creator registration counter (`CREATORS_REGISTERED_TOTAL`)
  - tip success/failure counters and amount histogram
  - corrected DB query histogram labeling usage
  - `src/controllers/creator_controller.rs`
  - `src/controllers/tip_controller.rs`
- Added Prometheus recording rules for metric aggregation:
  - `monitoring/prometheus/recording_rules.yml`
  - wired into `monitoring/prometheus/prometheus.yml`
  - mounted in `compose.yml`
- Updated Grafana dashboard to consume aggregated time series:
  - `monitoring/grafana/dashboards/tipjar_overview.json`

## Validation

- Targeted test command attempted: `cargo test --test feature_tests api_mocking -- --nocapture`
- Full compile/test is currently blocked by pre-existing repository issues unrelated to this PR:
  - duplicate module declarations in other areas
  - existing SQLx online macro requirements without prepared cache/DB
  - existing unrelated type/trait errors in untouched modules

## Issue Closure

Closes #229  
Closes #234  
Closes #236  
Closes #240

