### PR TITLE
feat: implement tip comment system

### DIFF
--- a/migrations/0041_create_comments.down.sql
+++ b/migrations/0041_create_comments.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS comments;

--- a/migrations/0041_create_comments.sql
+++ b/migrations/0041_create_comments.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS comments (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tip_id      UUID NOT NULL REFERENCES tips(id) ON DELETE CASCADE,
+    parent_id   UUID REFERENCES comments(id) ON DELETE CASCADE,
+    author      TEXT NOT NULL,
+    body        TEXT NOT NULL CHECK (char_length(body) BETWEEN 1 AND 1000),
+    is_flagged  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_comments_tip_id    ON comments(tip_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_comments_parent_id ON comments(parent_id) WHERE parent_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_comments_flagged   ON comments(is_flagged) WHERE is_flagged = TRUE;

--- a/src/controllers/comment_controller.rs
+++ b/src/controllers/comment_controller.rs
@@ -1,0 +1,84 @@
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::errors::AppResult;
+use crate::models::comment::{Comment, CreateCommentRequest};
+
+/// Create a new comment (or reply) on a tip.
+pub async fn create_comment(
+    pool: &PgPool,
+    tip_id: Uuid,
+    req: CreateCommentRequest,
+) -> AppResult<Comment> {
+    let comment = sqlx::query_as::<_, Comment>(
+        r#"
+        INSERT INTO comments (id, tip_id, parent_id, author, body)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING id, tip_id, parent_id, author, body, is_flagged, created_at, updated_at
+        "#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(tip_id)
+    .bind(req.parent_id)
+    .bind(&req.author)
+    .bind(&req.body)
+    .fetch_one(pool)
+    .await?;
+    Ok(comment)
+}
+
+/// List top-level comments for a tip (parent_id IS NULL), ordered oldest-first.
+pub async fn list_comments(pool: &PgPool, tip_id: Uuid) -> AppResult<Vec<Comment>> {
+    let comments = sqlx::query_as::<_, Comment>(
+        r#"
+        SELECT id, tip_id, parent_id, author, body, is_flagged, created_at, updated_at
+        FROM comments
+        WHERE tip_id = $1 AND parent_id IS NULL AND is_flagged = FALSE
+        ORDER BY created_at ASC
+        "#,
+    )
+    .bind(tip_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(comments)
+}
+
+/// List replies to a specific comment.
+pub async fn list_replies(pool: &PgPool, parent_id: Uuid) -> AppResult<Vec<Comment>> {
+    let replies = sqlx::query_as::<_, Comment>(
+        r#"
+        SELECT id, tip_id, parent_id, author, body, is_flagged, created_at, updated_at
+        FROM comments
+        WHERE parent_id = $1 AND is_flagged = FALSE
+        ORDER BY created_at ASC
+        "#,
+    )
+    .bind(parent_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(replies)
+}
+
+/// Delete a comment by ID (hard delete).
+pub async fn delete_comment(pool: &PgPool, comment_id: Uuid) -> AppResult<()> {
+    sqlx::query("DELETE FROM comments WHERE id = $1")
+        .bind(comment_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Flag a comment for moderation review.
+pub async fn flag_comment(pool: &PgPool, comment_id: Uuid) -> AppResult<Comment> {
+    let comment = sqlx::query_as::<_, Comment>(
+        r#"
+        UPDATE comments SET is_flagged = TRUE, updated_at = NOW()
+        WHERE id = $1
+        RETURNING id, tip_id, parent_id, author, body, is_flagged, created_at, updated_at
+        "#,
+    )
+    .bind(comment_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(comment)
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -2,6 +2,7 @@ pub mod admin_controller;
 pub mod analytics_controller;
 pub mod api_key_controller;
 pub mod audit_log_controller;
+pub mod comment_controller;
 pub mod creator_controller;
 pub mod export_controller;
 pub mod feature_flag_controller;

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,6 +303,7 @@ async fn main() -> anyhow::Result<()> {
                         .merge(routes::auth::router())
                         .merge(routes::teams::router())
                         .merge(routes::tips::router())
+                        .merge(routes::comments::router())
                         .merge(routes::creators::write_router())
                         .merge(routes::verification::router())
                         .merge(routes::goals::router())

--- a/src/models/comment.rs
+++ b/src/models/comment.rs
@@ -1,0 +1,55 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::Validate;
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct Comment {
+    pub id: Uuid,
+    pub tip_id: Uuid,
+    pub parent_id: Option<Uuid>,
+    pub author: String,
+    pub body: String,
+    pub is_flagged: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct CreateCommentRequest {
+    /// Author identifier (username or display name)
+    #[validate(length(min = 1, max = 50, message = "Author must be 1–50 characters"))]
+    pub author: String,
+
+    /// Comment body (1–1000 characters)
+    #[validate(length(min = 1, max = 1000, message = "Body must be 1–1000 characters"))]
+    pub body: String,
+
+    /// Optional parent comment ID for nested replies
+    pub parent_id: Option<Uuid>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CommentResponse {
+    pub id: Uuid,
+    pub tip_id: Uuid,
+    pub parent_id: Option<Uuid>,
+    pub author: String,
+    pub body: String,
+    pub is_flagged: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<Comment> for CommentResponse {
+    fn from(c: Comment) -> Self {
+        Self {
+            id: c.id,
+            tip_id: c.tip_id,
+            parent_id: c.parent_id,
+            author: c.author,
+            body: c.body,
+            is_flagged: c.is_flagged,
+            created_at: c.created_at,
+        }
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod audit_log;
 pub mod auth;
 pub mod campaign;
 pub mod category;
+pub mod comment;
 pub mod creator;
 pub mod feature_flag;
 pub mod follow;

--- a/src/routes/comments.rs
+++ b/src/routes/comments.rs
@@ -1,0 +1,99 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post},
+    Json, Router,
+};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::controllers::{comment_controller, notification_controller};
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::comment::{CommentResponse, CreateCommentRequest};
+use crate::moderation::ContentType;
+use crate::validation::ValidatedJson;
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/tips/:tip_id/comments", post(create_comment).get(list_comments))
+        .route("/tips/:tip_id/comments/:id/replies", get(list_replies))
+        .route("/tips/:tip_id/comments/:id", delete(delete_comment))
+        .route("/tips/:tip_id/comments/:id/flag", post(flag_comment))
+}
+
+async fn create_comment(
+    State(state): State<Arc<AppState>>,
+    Path(tip_id): Path<Uuid>,
+    ValidatedJson(body): ValidatedJson<CreateCommentRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // Moderate comment body before persisting.
+    let moderation = state
+        .moderation
+        .check_content(&body.body, ContentType::TipMessage, None)
+        .await;
+    if moderation.has_high_confidence_violation(0.90) {
+        return Err(AppError::bad_request("Comment was rejected by content moderation"));
+    }
+
+    let comment = comment_controller::create_comment(&state.db, tip_id, body).await?;
+
+    // Notify the tip's creator that a new comment was posted.
+    // Look up the creator username from the tip; ignore errors so the comment still succeeds.
+    if let Ok(row) = sqlx::query_scalar::<_, String>(
+        "SELECT creator_username FROM tips WHERE id = $1",
+    )
+    .bind(tip_id)
+    .fetch_one(&state.db)
+    .await
+    {
+        let _ = notification_controller::create_notification(
+            &state.db,
+            &row,
+            "comment_received",
+            serde_json::json!({
+                "tip_id": tip_id,
+                "comment_id": comment.id,
+                "author": comment.author,
+            }),
+        )
+        .await;
+    }
+
+    Ok((StatusCode::CREATED, Json(CommentResponse::from(comment))))
+}
+
+async fn list_comments(
+    State(state): State<Arc<AppState>>,
+    Path(tip_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let comments = comment_controller::list_comments(&state.db, tip_id).await?;
+    let response: Vec<CommentResponse> = comments.into_iter().map(CommentResponse::from).collect();
+    Ok((StatusCode::OK, Json(response)))
+}
+
+async fn list_replies(
+    State(state): State<Arc<AppState>>,
+    Path((_tip_id, comment_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, AppError> {
+    let replies = comment_controller::list_replies(&state.db, comment_id).await?;
+    let response: Vec<CommentResponse> = replies.into_iter().map(CommentResponse::from).collect();
+    Ok((StatusCode::OK, Json(response)))
+}
+
+async fn delete_comment(
+    State(state): State<Arc<AppState>>,
+    Path((_tip_id, comment_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, AppError> {
+    comment_controller::delete_comment(&state.db, comment_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn flag_comment(
+    State(state): State<Arc<AppState>>,
+    Path((_tip_id, comment_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, AppError> {
+    let comment = comment_controller::flag_comment(&state.db, comment_id).await?;
+    Ok((StatusCode::OK, Json(CommentResponse::from(comment))))
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -5,6 +5,7 @@ pub mod audit_logs;
 pub mod auth;
 pub mod categories;
 pub mod cdn;
+pub mod comments;
 pub mod creators;
 pub mod currency;
 pub mod deprecation;


### PR DESCRIPTION
i Add comments table with nested replies via parent_id (migration 0041)
- Comment model with CreateCommentRequest validation
- CRUD controller: create, list, list_replies, delete, flag
- Routes: POST/GET /tips/:id/comments, replies, delete, flag
- Content moderation on comment body (90% confidence threshold)
- comment_received notification fired to tip creator on new comment
- Registered under /api/v1 write_limiter


closes #178 