### PR TITLE
Add Tip Amount Limits and Per-Creator Rate Limiting

### DIFF
--- a/migrations/0043_tip_limits_and_rate_tracking.down.sql
+++ b/migrations/0043_tip_limits_and_rate_tracking.down.sql
@@ -1,0 +1,12 @@
+DROP INDEX IF EXISTS idx_tips_creator_recent;
+DROP INDEX IF EXISTS idx_tips_tipper_ip_created;
+DROP INDEX IF EXISTS idx_tips_tipper_wallet_created;
+
+ALTER TABLE tips
+    DROP COLUMN IF EXISTS tipper_ip,
+    DROP COLUMN IF EXISTS tipper_wallet;
+
+ALTER TABLE creators
+    DROP COLUMN IF EXISTS max_tips_per_minute,
+    DROP COLUMN IF EXISTS max_tip_amount,
+    DROP COLUMN IF EXISTS min_tip_amount;

--- a/migrations/0043_tip_limits_and_rate_tracking.sql
+++ b/migrations/0043_tip_limits_and_rate_tracking.sql
@@ -1,0 +1,12 @@
+ALTER TABLE creators
+    ADD COLUMN IF NOT EXISTS min_tip_amount TEXT,
+    ADD COLUMN IF NOT EXISTS max_tip_amount TEXT,
+    ADD COLUMN IF NOT EXISTS max_tips_per_minute INTEGER;
+
+ALTER TABLE tips
+    ADD COLUMN IF NOT EXISTS tipper_wallet TEXT,
+    ADD COLUMN IF NOT EXISTS tipper_ip TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_tips_tipper_wallet_created ON tips(tipper_wallet, created_at DESC) WHERE tipper_wallet IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_tips_tipper_ip_created ON tips(tipper_ip, created_at DESC) WHERE tipper_ip IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_tips_creator_recent ON tips(creator_username, created_at DESC);

--- a/src/controllers/tip_controller.rs
+++ b/src/controllers/tip_controller.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::{net::IpAddr, time::Instant};
 use uuid::Uuid;
 
 use crate::cache::{keys, redis_client};
@@ -12,10 +12,25 @@ use crate::metrics::collectors::{
 };
 use crate::models::pagination::{PaginatedResponse, PaginationParams};
 use crate::models::tip::{RecordTipRequest, ReportMessageRequest, Tip, TipFilters, TipSortParams};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TipRecordContext {
+    pub ip: Option<IpAddr>,
+}
+
 use crate::moderation::ContentType;
 
 #[tracing::instrument(skip(state), fields(username = %req.username, amount = %req.amount))]
 pub async fn record_tip(state: &AppState, req: RecordTipRequest) -> AppResult<Tip> {
+    record_tip_with_context(state, req, TipRecordContext::default()).await
+}
+
+#[tracing::instrument(skip(state), fields(username = %req.username, amount = %req.amount, ip = ?context.ip))]
+pub async fn record_tip_with_context(
+    state: &AppState,
+    req: RecordTipRequest,
+    context: TipRecordContext,
+) -> AppResult<Tip> {
     // Moderate the tip message when provided.
     if let Some(ref msg) = req.message {
         if !msg.trim().is_empty() {
@@ -42,15 +57,16 @@ pub async fn record_tip(state: &AppState, req: RecordTipRequest) -> AppResult<Ti
 
     let start = Instant::now();
     // Pass state into the internal helper to support WebSocket broadcasting
-    let (tip, match_result) = match record_tip_in_tx(state, &mut tx, &req).await {
-        Ok(result) => result,
-        Err(e) => {
-            TIPS_FAILED_TOTAL
-                .with_label_values(&["record_tip_in_tx"])
-                .inc();
-            return Err(e);
-        }
-    };
+    let (tip, match_result) =
+        match record_tip_in_tx_with_context(state, &mut tx, &req, context).await {
+            Ok(result) => result,
+            Err(e) => {
+                TIPS_FAILED_TOTAL
+                    .with_label_values(&["record_tip_in_tx"])
+                    .inc();
+                return Err(e);
+            }
+        };
     tx.commit().await?;
     let duration = start.elapsed();
 
@@ -154,9 +170,18 @@ pub async fn record_tip_in_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     req: &RecordTipRequest,
 ) -> AppResult<(Tip, Option<crate::models::campaign::CampaignMatchResult>)> {
+    record_tip_in_tx_with_context(state, tx, req, TipRecordContext::default()).await
+}
+
+pub async fn record_tip_in_tx_with_context(
+    state: &AppState,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    req: &RecordTipRequest,
+    context: TipRecordContext,
+) -> AppResult<(Tip, Option<crate::models::campaign::CampaignMatchResult>)> {
     let query_tip = r#"
-        INSERT INTO tips (id, creator_username, amount, transaction_hash, message, message_visibility, created_at)
-        VALUES ($1, $2, $3, $4, $5, $6, NOW())
+        INSERT INTO tips (id, creator_username, amount, transaction_hash, message, message_visibility, tipper_wallet, tipper_ip, created_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
         RETURNING id, creator_username, amount, transaction_hash, message, message_visibility, created_at
         "#;
 
@@ -167,6 +192,8 @@ pub async fn record_tip_in_tx(
         .bind(&req.transaction_hash)
         .bind(&req.message)
         .bind(req.message_visibility.as_str())
+        .bind(&req.tipper_wallet)
+        .bind(context.ip.map(|ip| ip.to_string()))
         .fetch_one(&mut **tx)
         .await?;
 

--- a/src/cqrs/handlers.rs
+++ b/src/cqrs/handlers.rs
@@ -99,8 +99,10 @@ impl CommandHandler for RecordTipHandler {
             RecordTipRequest {
                 username: creator_username,
                 amount,
+                tipper_wallet: None,
                 transaction_hash,
                 message: None,
+                message_visibility: crate::models::tip::MessageVisibility::Public,
             },
         )
         .await?;

--- a/src/graphql/mutations.rs
+++ b/src/graphql/mutations.rs
@@ -19,6 +19,7 @@ pub struct CreateCreatorInput {
 pub struct RecordTipInput {
     pub username: String,
     pub amount: String,
+    pub tipper_wallet: Option<String>,
     pub transaction_hash: String,
 }
 
@@ -58,8 +59,10 @@ impl MutationRoot {
         let req = RecordTipRequest {
             username: input.username,
             amount: input.amount,
+            tipper_wallet: input.tipper_wallet,
             transaction_hash: input.transaction_hash,
             message: None,
+            message_visibility: crate::models::tip::MessageVisibility::Public,
         };
         req.validate()
             .map_err(|e| async_graphql::Error::new(e.to_string()))?;

--- a/src/models/tip.rs
+++ b/src/models/tip.rs
@@ -71,6 +71,10 @@ pub struct RecordTipRequest {
     #[validate(custom(function = "crate::validation::amount::validate_xlm_amount"))]
     pub amount: String,
 
+    /// Optional wallet address for the tipper; used for per-wallet rate limiting.
+    #[validate(custom(function = "crate::validation::stellar::validate_stellar_address"))]
+    pub tipper_wallet: Option<String>,
+
     /// Stellar transaction hash — 64 hex characters
     #[validate(length(equal = 64, message = "Transaction hash must be exactly 64 characters"))]
     #[validate(custom(function = "validate_tx_hash"))]
@@ -180,7 +184,11 @@ impl From<Tip> for TipResponse {
 #[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct ReportMessageRequest {
     /// Reason for the report
-    #[validate(length(min = 10, max = 500, message = "Reason must be between 10 and 500 characters"))]
+    #[validate(length(
+        min = 10,
+        max = 500,
+        message = "Reason must be between 10 and 500 characters"
+    ))]
     pub reason: String,
     /// Reporter identifier (username or anonymous)
     #[validate(length(max = 50))]

--- a/src/routes/tips.rs
+++ b/src/routes/tips.rs
@@ -1,18 +1,20 @@
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
-use std::sync::Arc;
+use std::{net::IpAddr, sync::Arc};
 use uuid::Uuid;
 
 use crate::controllers::tip_controller;
 use crate::db::connection::AppState;
 use crate::errors::{AppError, StellarError};
 use crate::models::pagination::PaginationParams;
-use crate::models::tip::{RecordTipRequest, ReportMessageRequest, TipFilters, TipResponse, TipSortParams};
+use crate::models::tip::{
+    RecordTipRequest, ReportMessageRequest, TipFilters, TipResponse, TipSortParams,
+};
 use crate::services::validation_service::{TipValidationService, ValidationRules};
 
 pub fn router() -> Router<Arc<AppState>> {
@@ -36,10 +38,14 @@ pub fn router() -> Router<Arc<AppState>> {
 )]
 pub async fn record_tip(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<RecordTipRequest>,
 ) -> Result<impl IntoResponse, AppError> {
+    let client_ip = extract_client_ip(&headers);
     let validator = TipValidationService::new(ValidationRules::default());
-    validator.validate(&state.db, &body).await?;
+    validator
+        .validate_with_client(&state.db, &body, client_ip)
+        .await?;
 
     match state
         .stellar
@@ -55,7 +61,12 @@ pub async fn record_tip(
         Ok(true) => {}
     }
 
-    let tip = tip_controller::record_tip(&state, body).await?;
+    let tip = tip_controller::record_tip_with_context(
+        &state,
+        body,
+        tip_controller::TipRecordContext { ip: client_ip },
+    )
+    .await?;
     let response: TipResponse = tip.into();
     Ok((StatusCode::CREATED, Json(serde_json::json!(response))).into_response())
 }
@@ -102,4 +113,19 @@ pub async fn report_tip_message(
 ) -> Result<impl IntoResponse, AppError> {
     tip_controller::report_tip_message(&state, id, body).await?;
     Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+pub(crate) fn extract_client_ip(headers: &HeaderMap) -> Option<IpAddr> {
+    headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.split(',').next())
+        .map(str::trim)
+        .and_then(|v| v.parse().ok())
+        .or_else(|| {
+            headers
+                .get("x-real-ip")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse().ok())
+        })
 }

--- a/src/routes/v1/mod.rs
+++ b/src/routes/v1/mod.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use crate::controllers::{creator_controller, tip_controller};
 use crate::db::connection::AppState;
 use crate::errors::AppError;
-use crate::models::tip::{RecordTipRequest, TipFilters, TipSortParams};
 use crate::models::pagination::PaginationParams;
+use crate::models::tip::{RecordTipRequest, TipFilters, TipSortParams};
 
 /// Slim creator shape — v1 omits timestamps and optional fields.
 #[derive(Serialize)]
@@ -98,10 +98,22 @@ async fn get_creator_tips(
 
 async fn record_tip(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<RecordTipRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     use crate::errors::StellarError;
-    match state.stellar.verify_transaction(&body.transaction_hash).await {
+    let client_ip = crate::routes::tips::extract_client_ip(&headers);
+    let validator = crate::services::validation_service::TipValidationService::new(
+        crate::services::validation_service::ValidationRules::default(),
+    );
+    validator
+        .validate_with_client(&state.db, &body, client_ip)
+        .await?;
+    match state
+        .stellar
+        .verify_transaction(&body.transaction_hash)
+        .await
+    {
         Ok(false) => {
             return Err(AppError::Stellar(StellarError::TransactionNotFound {
                 hash: body.transaction_hash.clone(),
@@ -110,7 +122,12 @@ async fn record_tip(
         Err(e) => return Err(e),
         Ok(true) => {}
     }
-    let t = tip_controller::record_tip(&state, body).await?;
+    let t = tip_controller::record_tip_with_context(
+        &state,
+        body,
+        tip_controller::TipRecordContext { ip: client_ip },
+    )
+    .await?;
     Ok((
         StatusCode::CREATED,
         Json(TipResponseV1 {

--- a/src/routes/v2/mod.rs
+++ b/src/routes/v2/mod.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
@@ -80,10 +80,22 @@ async fn get_creator_tips(
 
 async fn record_tip(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<RecordTipRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     use crate::errors::StellarError;
-    match state.stellar.verify_transaction(&body.transaction_hash).await {
+    let client_ip = crate::routes::tips::extract_client_ip(&headers);
+    let validator = crate::services::validation_service::TipValidationService::new(
+        crate::services::validation_service::ValidationRules::default(),
+    );
+    validator
+        .validate_with_client(&state.db, &body, client_ip)
+        .await?;
+    match state
+        .stellar
+        .verify_transaction(&body.transaction_hash)
+        .await
+    {
         Ok(false) => {
             return Err(AppError::Stellar(StellarError::TransactionNotFound {
                 hash: body.transaction_hash.clone(),
@@ -92,7 +104,12 @@ async fn record_tip(
         Err(e) => return Err(e),
         Ok(true) => {}
     }
-    let t = tip_controller::record_tip(&state, body).await?;
+    let t = tip_controller::record_tip_with_context(
+        &state,
+        body,
+        tip_controller::TipRecordContext { ip: client_ip },
+    )
+    .await?;
     Ok((StatusCode::CREATED, Json(TipResponse::from(t))))
 }
 

--- a/src/saga/tip_saga.rs
+++ b/src/saga/tip_saga.rs
@@ -42,8 +42,10 @@ impl SagaAction for RecordTipStep {
             RecordTipRequest {
                 username: self.req.username.clone(),
                 amount: self.req.amount.clone(),
+                tipper_wallet: self.req.tipper_wallet.clone(),
                 transaction_hash: self.req.transaction_hash.clone(),
                 message: self.req.message.clone(),
+                message_visibility: self.req.message_visibility.clone(),
             },
         )
         .await?;
@@ -117,8 +119,10 @@ pub async fn run_tip_saga(state: Arc<AppState>, req: RecordTipRequest) -> AppRes
                 req: RecordTipRequest {
                     username: req.username.clone(),
                     amount: req.amount.clone(),
+                    tipper_wallet: req.tipper_wallet.clone(),
                     transaction_hash: req.transaction_hash.clone(),
                     message: req.message.clone(),
+                    message_visibility: req.message_visibility.clone(),
                 },
             }),
             compensation: Box::new(DeleteTipCompensation {

--- a/src/services/validation_service.rs
+++ b/src/services/validation_service.rs
@@ -1,6 +1,6 @@
 use rust_decimal::Decimal;
 use sqlx::PgPool;
-use std::str::FromStr;
+use std::{net::IpAddr, str::FromStr};
 
 use crate::errors::{AppError, AppResult};
 use crate::models::tip::RecordTipRequest;
@@ -10,24 +10,43 @@ use crate::models::tip::RecordTipRequest;
 pub struct ValidationRules {
     pub min_tip_xlm: Decimal,
     pub max_tip_xlm: Decimal,
+    pub tips_per_minute: i64,
 }
 
 impl Default for ValidationRules {
     fn default() -> Self {
-        let min = std::env::var("TIP_MIN_XLM")
-            .ok()
-            .and_then(|v| Decimal::from_str(&v).ok())
+        let min = decimal_env("MIN_TIP_AMOUNT")
+            .or_else(|| decimal_env("TIP_MIN_XLM"))
             .unwrap_or_else(|| Decimal::from_str("0.01").unwrap());
-        let max = std::env::var("TIP_MAX_XLM")
-            .ok()
-            .and_then(|v| Decimal::from_str(&v).ok())
+        let max = decimal_env("MAX_TIP_AMOUNT")
+            .or_else(|| decimal_env("TIP_MAX_XLM"))
             .unwrap_or_else(|| Decimal::from_str("10000").unwrap());
-        Self { min_tip_xlm: min, max_tip_xlm: max }
+        let tips_per_minute = std::env::var("TIP_RATE_LIMIT_PER_MINUTE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10);
+        Self {
+            min_tip_xlm: min,
+            max_tip_xlm: max,
+            tips_per_minute,
+        }
     }
+}
+
+fn decimal_env(key: &str) -> Option<Decimal> {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| Decimal::from_str(&v).ok())
 }
 
 pub struct TipValidationService {
     rules: ValidationRules,
+}
+
+struct CreatorTipLimits {
+    min_tip_amount: Option<String>,
+    max_tip_amount: Option<String>,
+    max_tips_per_minute: Option<i32>,
 }
 
 impl TipValidationService {
@@ -38,31 +57,125 @@ impl TipValidationService {
     /// Run all business-logic checks before a tip is persisted.
     /// Call this after input validation (ValidatedJson) but before Stellar verification.
     pub async fn validate(&self, pool: &PgPool, req: &RecordTipRequest) -> AppResult<()> {
-        self.check_amount(&req.amount)?;
+        self.validate_with_client(pool, req, None).await
+    }
+
+    pub async fn validate_with_client(
+        &self,
+        pool: &PgPool,
+        req: &RecordTipRequest,
+        ip: Option<IpAddr>,
+    ) -> AppResult<()> {
+        let creator_limits = self.fetch_creator_limits(pool, &req.username).await?;
+        self.check_amount(&req.amount, &creator_limits)?;
+        self.check_rate_limits(pool, req, ip, &creator_limits)
+            .await?;
         self.check_duplicate(pool, &req.transaction_hash).await?;
-        self.check_creator_exists(pool, &req.username).await?;
         self.check_fraud_indicators(pool, req).await;
         Ok(())
     }
 
-    fn check_amount(&self, amount: &str) -> AppResult<()> {
+    async fn fetch_creator_limits(
+        &self,
+        pool: &PgPool,
+        username: &str,
+    ) -> AppResult<CreatorTipLimits> {
+        let limits = sqlx::query_as::<_, (Option<String>, Option<String>, Option<i32>)>(
+            "SELECT min_tip_amount, max_tip_amount, max_tips_per_minute FROM creators WHERE username = $1",
+        )
+        .bind(username)
+        .fetch_optional(pool)
+        .await?;
+
+        match limits {
+            Some((min_tip_amount, max_tip_amount, max_tips_per_minute)) => Ok(CreatorTipLimits {
+                min_tip_amount,
+                max_tip_amount,
+                max_tips_per_minute,
+            }),
+            None => Err(AppError::CreatorNotFound {
+                username: username.to_string(),
+            }),
+        }
+    }
+
+    fn check_amount(&self, amount: &str, creator_limits: &CreatorTipLimits) -> AppResult<()> {
         let value = Decimal::from_str(amount).map_err(|_| AppError::Conflict {
             code: "INVALID_AMOUNT",
             message: "Tip amount is not a valid decimal".to_string(),
         })?;
 
-        if value < self.rules.min_tip_xlm {
+        let min = creator_limits
+            .min_tip_amount
+            .as_deref()
+            .and_then(|v| Decimal::from_str(v).ok())
+            .unwrap_or(self.rules.min_tip_xlm);
+        let max = creator_limits
+            .max_tip_amount
+            .as_deref()
+            .and_then(|v| Decimal::from_str(v).ok())
+            .unwrap_or(self.rules.max_tip_xlm);
+
+        if value < min {
             return Err(AppError::Conflict {
                 code: "AMOUNT_TOO_LOW",
-                message: format!("Minimum tip amount is {} XLM", self.rules.min_tip_xlm),
+                message: format!("Minimum tip amount is {min} XLM"),
             });
         }
-        if value > self.rules.max_tip_xlm {
+        if value > max {
             return Err(AppError::Conflict {
                 code: "AMOUNT_TOO_HIGH",
-                message: format!("Maximum tip amount is {} XLM", self.rules.max_tip_xlm),
+                message: format!("Maximum tip amount is {max} XLM"),
             });
         }
+        Ok(())
+    }
+
+    async fn check_rate_limits(
+        &self,
+        pool: &PgPool,
+        req: &RecordTipRequest,
+        ip: Option<IpAddr>,
+        creator_limits: &CreatorTipLimits,
+    ) -> AppResult<()> {
+        let limit = creator_limits
+            .max_tips_per_minute
+            .map(i64::from)
+            .unwrap_or(self.rules.tips_per_minute);
+        let retry_after_secs = 60;
+
+        if let Some(ip) = ip {
+            let count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM tips WHERE tipper_ip = $1 AND created_at > NOW() - INTERVAL '1 minute'",
+            )
+            .bind(ip.to_string())
+            .fetch_one(pool)
+            .await?;
+            if count >= limit {
+                log_rate_limit_violation(req, Some(ip), "ip", count, limit);
+                return Err(AppError::rate_limited_with_retry(
+                    "Too many tips from this IP address. Please slow down.",
+                    retry_after_secs,
+                ));
+            }
+        }
+
+        if let Some(wallet) = req.tipper_wallet.as_deref() {
+            let count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM tips WHERE tipper_wallet = $1 AND created_at > NOW() - INTERVAL '1 minute'",
+            )
+            .bind(wallet)
+            .fetch_one(pool)
+            .await?;
+            if count >= limit {
+                log_rate_limit_violation(req, ip, "wallet", count, limit);
+                return Err(AppError::rate_limited_with_retry(
+                    "Too many tips from this wallet. Please slow down.",
+                    retry_after_secs,
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -78,19 +191,6 @@ impl TipValidationService {
                 code: "DUPLICATE_TRANSACTION",
                 message: "This transaction has already been recorded".to_string(),
             });
-        }
-        Ok(())
-    }
-
-    async fn check_creator_exists(&self, pool: &PgPool, username: &str) -> AppResult<()> {
-        let exists: bool =
-            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM creators WHERE username = $1)")
-                .bind(username)
-                .fetch_one(pool)
-                .await?;
-
-        if !exists {
-            return Err(AppError::CreatorNotFound { username: username.to_string() });
         }
         Ok(())
     }
@@ -112,6 +212,7 @@ impl TipValidationService {
             if count > 5 {
                 tracing::warn!(
                     creator = %req.username,
+                    wallet = ?req.tipper_wallet,
                     amount = %req.amount,
                     count = count,
                     "Fraud signal: repeated same-amount tips within 1 hour"
@@ -119,4 +220,22 @@ impl TipValidationService {
             }
         }
     }
+}
+
+fn log_rate_limit_violation(
+    req: &RecordTipRequest,
+    ip: Option<IpAddr>,
+    limit_type: &'static str,
+    count: i64,
+    limit: i64,
+) {
+    tracing::warn!(
+        creator = %req.username,
+        wallet = ?req.tipper_wallet,
+        ip = ?ip,
+        limit_type,
+        count,
+        limit,
+        "Tip rate limit exceeded"
+    );
 }

--- a/tests/team_test.rs
+++ b/tests/team_test.rs
@@ -90,8 +90,10 @@ async fn test_team_tip_split_history_and_recording() {
     let record_req = RecordTipRequest {
         username: member_username.clone(),
         amount: "10".to_string(),
+        tipper_wallet: None,
         transaction_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
         message: None,
+        message_visibility: stellar_tipjar_backend::models::tip::MessageVisibility::Public,
     };
 
     let (tip, _) = tip_controller::record_tip_in_tx(&state, &mut tx, &record_req)


### PR DESCRIPTION
close #306 

Description
Add a DB migration that adds min_tip_amount, max_tip_amount, and max_tips_per_minute to creators and tipper_wallet and tipper_ip to tips, plus indexes to support recent-count queries. (migrations/0043_tip_limits_and_rate_tracking.sql).
Wire configurable env vars into validation: MIN_TIP_AMOUNT and MAX_TIP_AMOUNT are read (with backward-compatible fallbacks to TIP_MIN_XLM / TIP_MAX_XLM) and a TIP_RATE_LIMIT_PER_MINUTE default (10) is used when not set.
Add TipValidationService::validate_with_client to enforce creator- and global-level amount checks and per-IP / per-wallet one-minute rate limits (default 10/min), using a per-creator override from creators.max_tips_per_minute when present.
Surface client IP from X-Forwarded-For/X-Real-IP in the tips routes, accept an optional tipper_wallet in RecordTipRequest, persist wallet/IP when recording tips, and return 429 Too Many Requests via AppError::rate_limited_with_retry including a Retry-After header when limits are exceeded; all rate-limit violations are logged with creator, wallet and IP context.

Testing
Ran rustfmt on modified files (succeeded) to ensure style consistency.
Attempted cargo fmt and cargo check, but the full build/test run could not complete due to unrelated environment/repo issues (external Swagger UI download blocked without a local zip, sqlx query-macro caching requiring DATABASE_URL/sqlx prepare, and some pre-existing missing template/test files), so end-to-end compile/tests were not fully executed in this environment.
Unit-level edits were exercised by local formatting and some targeted cargo check invocations where possible, but CI/local run is required to validate full compilation and integration tests.
