### PR TITLE
feat(docs): implement API documentation portal

### DIFF
--- a/src/docs/mod.rs
+++ b/src/docs/mod.rs
@@ -1,3 +1,5 @@
+pub mod portal;
+
 use utoipa::{
     openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme},
     Modify, OpenApi,
@@ -43,6 +45,8 @@ impl Modify for BearerAuth {
 Backend API for the Stellar Tipjar — create creator profiles and record on-chain tips
 verified against the Stellar network.
 
+> **Interactive docs:** [Redoc portal](/docs) | [Swagger UI](/swagger-ui) | [SDK guide](/docs/sdk)
+
 ## Authentication
 Most write endpoints require a JWT Bearer token obtained via `POST /auth/login`.
 
@@ -55,25 +59,40 @@ Access tokens expire after **15 minutes**. Use `POST /auth/refresh` with your
 `refresh_token` to obtain a new pair.
 
 ## Rate Limiting
-- **Read endpoints**: 120 req/min per IP
-- **Write endpoints**: 30 req/min per IP
+| Tier | Limit | Applies to |
+|------|-------|------------|
+| Read | 120 req/min per IP | GET endpoints |
+| Write | 30 req/min per IP | POST / PUT / DELETE |
+
+HTTP `429 Too Many Requests` is returned when exceeded. Check the `Retry-After` header.
 
 ## Multi-Tenancy
 Tenant-scoped endpoints require an `X-Tenant-ID` header containing the tenant UUID.
 
 ## Versioning
-All endpoints are available under `/api/v1` and `/api/v2`.
+All endpoints are available under `/api/v1` (legacy, deprecated) and `/api/v2` (current).
 
 ## Cursor Pagination
 Cursor-based pagination uses a composite cursor of `created_at` timestamp and `id`.
-The cursor value is a base64-encoded string of the form `"<timestamp>|<uuid>"` where
-`<timestamp>` is unix seconds and `<uuid>` is the tip's UUID. Example: base64("1620000000|550e8400-e29b-41d4-a716-446655440000").
+The cursor value is a base64-encoded string of the form `\"<timestamp>|<uuid>\"` where
+`<timestamp>` is unix seconds and `<uuid>` is the tip's UUID.
+Example: `base64(\"1620000000|550e8400-e29b-41d4-a716-446655440000\")`.
+
+## Errors
+All errors follow a consistent envelope:
+```json
+{ \"error\": { \"code\": \"VALIDATION_ERROR\", \"message\": \"...\", \"details\": {} } }
+```
         ",
         contact(
             name = "Stellar Tipjar Team",
             url = "https://github.com/stellar-tipjar"
         ),
         license(name = "MIT")
+    ),
+    servers(
+        (url = "http://localhost:8000", description = "Local development"),
+        (url = "https://api.stellar-tipjar.com", description = "Production"),
     ),
     paths(
         // Health

--- a/src/docs/portal.rs
+++ b/src/docs/portal.rs
@@ -1,0 +1,44 @@
+//! API Documentation Portal — serves Redoc UI and SDK quickstart guide.
+
+use axum::{
+    http::header,
+    response::{Html, IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use std::sync::Arc;
+
+use crate::db::connection::AppState;
+
+const PORTAL_HTML: &str = include_str!("../../static/docs/portal.html");
+const SDK_HTML: &str = include_str!("../../static/docs/sdk.html");
+
+/// Serves the interactive Redoc documentation portal at `/docs`.
+pub async fn portal_handler() -> impl IntoResponse {
+    Html(PORTAL_HTML)
+}
+
+/// Serves the SDK quickstart guide at `/docs/sdk`.
+pub async fn sdk_guide_handler() -> impl IntoResponse {
+    Html(SDK_HTML)
+}
+
+/// Serves the raw OpenAPI JSON spec at `/docs/openapi.json`.
+pub async fn openapi_json_handler() -> Response {
+    use crate::docs::ApiDoc;
+    use utoipa::OpenApi;
+
+    let spec = ApiDoc::openapi().to_json().unwrap_or_default();
+    (
+        [(header::CONTENT_TYPE, "application/json; charset=utf-8")],
+        spec,
+    )
+        .into_response()
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/docs", get(portal_handler))
+        .route("/docs/sdk", get(sdk_guide_handler))
+        .route("/docs/openapi.json", get(openapi_json_handler))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub fn create_app(state: Arc<AppState>) -> Router {
 
     Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        .merge(docs::portal::router())
         .merge(routes::feature_flags::router(Arc::clone(&state)))
         .merge(routes::usage_analytics::router(Arc::clone(&state)))
         .merge(routes::refunds::admin_router(Arc::clone(&state)))

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,6 +453,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/metrics", axum::routing::get(metrics_handler))
         .route("/metrics/summary", axum::routing::get(metrics_summary_handler))
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        .merge(docs::portal::router())
         .merge(routes::monitoring::router(Arc::clone(&state), Arc::clone(&monitor)))
         .merge(routes::mesh::router(Arc::clone(&state), Arc::clone(&service_registry)))
         .merge(routes::load_balancer::router(Arc::clone(&state), Arc::clone(&service_registry)))

--- a/static/docs/portal.html
+++ b/static/docs/portal.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stellar Tipjar — API Docs</title>
+  <link rel="icon" href="https://stellar.org/favicon.ico" />
+  <style>
+    :root {
+      --brand: #3b82f6; --bg: #0f172a; --surface: #1e293b;
+      --text: #e2e8f0; --muted: #94a3b8; --border: #334155;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: var(--bg); color: var(--text); font-family: system-ui, sans-serif; }
+    header {
+      display: flex; align-items: center; gap: 16px; padding: 14px 28px;
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      position: sticky; top: 0; z-index: 100;
+    }
+    header h1 { font-size: 1.1rem; font-weight: 600; }
+    .badge {
+      font-size: 0.7rem; padding: 2px 8px; border-radius: 9999px;
+      background: var(--brand); color: #fff; font-weight: 700;
+    }
+    nav { margin-left: auto; display: flex; align-items: center; gap: 24px; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.85rem; transition: color .15s; }
+    nav a:hover, nav a.active { color: var(--text); }
+    #redoc-container { min-height: calc(100vh - 56px); }
+  </style>
+</head>
+<body>
+  <header>
+    <span style="font-size:1.5rem">&#x1F680;</span>
+    <h1>Stellar Tipjar API</h1>
+    <span class="badge">v1.0</span>
+    <nav>
+      <a href="/docs" class="active">Reference</a>
+      <a href="/docs/sdk">SDK Guide</a>
+      <a href="/swagger-ui">Swagger UI</a>
+      <a href="/docs/openapi.json">OpenAPI JSON</a>
+    </nav>
+  </header>
+  <div id="redoc-container"></div>
+  <script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
+  <script>
+    Redoc.init('/docs/openapi.json', {
+      theme: {
+        colors: { primary: { main: '#3b82f6' } },
+        typography: {
+          fontSize: '15px',
+          fontFamily: 'system-ui, sans-serif',
+          code: { fontSize: '13px' }
+        },
+        sidebar: { backgroundColor: '#1e293b', textColor: '#e2e8f0' },
+        rightPanel: { backgroundColor: '#0d1117' },
+        codeBlock: { backgroundColor: '#0d1117' },
+      },
+      hideDownloadButton: false,
+      expandResponses: '200,201',
+      requiredPropsFirst: true,
+      sortPropsAlphabetically: false,
+      showExtensions: true,
+    }, document.getElementById('redoc-container'));
+  </script>
+</body>
+</html>

--- a/static/docs/sdk.html
+++ b/static/docs/sdk.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stellar Tipjar — SDK Guide</title>
+  <style>
+    :root {
+      --brand: #3b82f6; --bg: #0f172a; --surface: #1e293b;
+      --text: #e2e8f0; --muted: #94a3b8; --border: #334155; --code-bg: #0d1117;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: var(--bg); color: var(--text); font-family: system-ui, sans-serif; line-height: 1.6; }
+    header {
+      display: flex; align-items: center; gap: 16px; padding: 14px 28px;
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      position: sticky; top: 0; z-index: 100;
+    }
+    header h1 { font-size: 1.1rem; font-weight: 600; }
+    nav { margin-left: auto; display: flex; gap: 24px; }
+    nav a { color: var(--muted); text-decoration: none; font-size: 0.85rem; }
+    nav a:hover, nav a.active { color: var(--text); }
+    .wrap { max-width: 860px; margin: 0 auto; padding: 48px 24px 80px; }
+    h2 { font-size: 1.4rem; margin: 40px 0 12px; border-bottom: 1px solid var(--border); padding-bottom: 8px; }
+    h3 { font-size: 1rem; margin: 28px 0 8px; color: var(--brand); }
+    p, li { color: var(--muted); margin-bottom: 8px; font-size: 0.93rem; }
+    ul { padding-left: 20px; }
+    a { color: var(--brand); }
+    .alert {
+      background: #1e3a5f; border-left: 3px solid var(--brand);
+      padding: 12px 16px; border-radius: 4px; margin: 12px 0 20px; font-size: 0.9rem;
+    }
+    .tabs { display: flex; border-bottom: 1px solid var(--border); }
+    .tab {
+      padding: 8px 18px; cursor: pointer; font-size: 0.82rem; color: var(--muted);
+      background: none; border: none; border-bottom: 2px solid transparent;
+      margin-bottom: -1px; transition: all .15s;
+    }
+    .tab.active { color: var(--brand); border-bottom-color: var(--brand); }
+    .panel { display: none; }
+    .panel.active { display: block; }
+    pre {
+      background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px;
+      padding: 18px; overflow-x: auto; font-size: 0.8rem; line-height: 1.6; margin: 0 0 24px;
+    }
+    code { font-family: 'Fira Code', monospace; color: #cdd6f4; }
+    .kw { color: #ff79c6; } .str { color: #f1fa8c; } .cm { color: #6272a4; }
+    .fn { color: #50fa7b; } .ty { color: #8be9fd; } .nm { color: #bd93f9; }
+    .pill {
+      display: inline-block; font-size: 0.68rem; padding: 2px 7px; border-radius: 4px;
+      font-weight: 700; margin-right: 4px; vertical-align: middle; color: #fff;
+    }
+    .POST { background: #1d4ed8; } .GET { background: #065f46; }
+    table { width: 100%; border-collapse: collapse; margin: 8px 0 24px; font-size: 0.84rem; }
+    th { text-align: left; color: var(--brand); border-bottom: 1px solid var(--border); padding: 8px; }
+    td { padding: 8px; border-bottom: 1px solid var(--border); color: var(--muted); }
+    td code { background: var(--surface); padding: 1px 5px; border-radius: 3px; font-size: 0.78rem; color: var(--text); }
+  </style>
+</head>
+<body>
+<header>
+  <span style="font-size:1.5rem">&#x1F680;</span>
+  <h1>Stellar Tipjar API</h1>
+  <nav>
+    <a href="/docs">Reference</a>
+    <a href="/docs/sdk" class="active">SDK Guide</a>
+    <a href="/swagger-ui">Swagger UI</a>
+    <a href="/docs/openapi.json">OpenAPI JSON</a>
+  </nav>
+</header>
+<div class="wrap">
+
+  <h2>Quickstart</h2>
+  <p>The Stellar Tipjar API lets you create creator profiles and record on-chain tips verified against the Stellar network.</p>
+  <div class="alert">
+    <strong>Production:</strong> <code>https://api.stellar-tipjar.com</code>
+    &nbsp;&nbsp;|&nbsp;&nbsp;
+    <strong>Local:</strong> <code>http://localhost:8000</code>
+  </div>
+
+  <h3>Authentication</h3>
+  <p>Obtain a JWT pair by registering or logging in, then pass the access token as a Bearer header:</p>
+  <pre><code>Authorization: Bearer &lt;access_token&gt;</code></pre>
+  <p>Access tokens expire after <strong>15 minutes</strong>. Refresh via <code>POST /api/v2/auth/refresh</code>.</p>
+
+  <h2>Code Samples</h2>
+
+  <!-- Register -->
+  <h3><span class="pill POST">POST</span> Register a creator</h3>
+  <div class="tabs" id="reg">
+    <button class="tab active" onclick="sw('reg',0)">cURL</button>
+    <button class="tab" onclick="sw('reg',1)">Python</button>
+    <button class="tab" onclick="sw('reg',2)">JavaScript</button>
+    <button class="tab" onclick="sw('reg',3)">Rust</button>
+  </div>
+  <div class="panel active"><pre><code>curl -X POST https://api.stellar-tipjar.com/api/v2/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "alice",
+    "wallet_address": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+    "password": "supersecret123"
+  }'</code></pre></div>
+  <div class="panel"><pre><code><span class="kw">import</span> requests
+
+resp = requests.post(
+    <span class="str">"https://api.stellar-tipjar.com/api/v2/auth/register"</span>,
+    json={
+        <span class="str">"username"</span>: <span class="str">"alice"</span>,
+        <span class="str">"wallet_address"</span>: <span class="str">"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"</span>,
+        <span class="str">"password"</span>: <span class="str">"supersecret123"</span>,
+    }
+)
+tokens = resp.json()
+access_token = tokens[<span class="str">"access_token"</span>]</code></pre></div>
+  <div class="panel"><pre><code><span class="kw">const</span> resp = <span class="kw">await</span> fetch(<span class="str">"https://api.stellar-tipjar.com/api/v2/auth/register"</span>, {
+  method: <span class="str">"POST"</span>,
+  headers: { <span class="str">"Content-Type"</span>: <span class="str">"application/json"</span> },
+  body: JSON.stringify({
+    username: <span class="str">"alice"</span>,
+    wallet_address: <span class="str">"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"</span>,
+    password: <span class="str">"supersecret123"</span>,
+  }),
+});
+<span class="kw">const</span> { access_token, refresh_token } = <span class="kw">await</span> resp.json();</code></pre></div>
+  <div class="panel"><pre><code><span class="kw">let</span> resp = reqwest::Client::new()
+    .post(<span class="str">"https://api.stellar-tipjar.com/api/v2/auth/register"</span>)
+    .json(&amp;serde_json::json!({
+        <span class="str">"username"</span>: <span class="str">"alice"</span>,
+        <span class="str">"wallet_address"</span>: <span class="str">"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"</span>,
+        <span class="str">"password"</span>: <span class="str">"supersecret123"</span>,
+    }))
+    .send().await?;
+<span class="kw">let</span> tokens: serde_json::Value = resp.json().await?;</code></pre></div>
+
+  <!-- Record Tip -->
+  <h3><span class="pill POST">POST</span> Record a tip</h3>
+  <div class="tabs" id="tip">
+    <button class="tab active" onclick="sw('tip',0)">cURL</button>
+    <button class="tab" onclick="sw('tip',1)">Python</button>
+    <button class="tab" onclick="sw('tip',2)">JavaScript</button>
+    <button class="tab" onclick="sw('tip',3)">Rust</button>
+  </div>
+  <div class="panel active"><pre><code>curl -X POST https://api.stellar-tipjar.com/api/v2/tips \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "username": "alice",
+    "amount": "10.5",
+    "transaction_hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "message": "Keep up the great work!"
+  }'</code></pre></div>
+  <div class="panel"><pre><code>resp = requests.post(
+    <span class="str">"https://api.stellar-tipjar.com/api/v2/tips"</span>,
+    headers={<span class="str">"Authorization"</span>: <span class="str">f"Bearer {access_token}"</span>},
+    json={
+        <span class="str">"username"</span>: <span class="str">"alice"</span>,
+        <span class="str">"amount"</span>: <span class="str">"10.5"</span>,
+        <span class="str">"transaction_hash"</span>: <span class="str">"a1b2c3d4..."</span>,
+        <span class="str">"message"</span>: <span class="str">"Keep up the great work!"</span>,
+    }
+)
+tip = resp.json()</code></pre></div>
+  <div class="panel"><pre><code><span class="kw">const</span> resp = <span class="kw">await</span> fetch(<span class="str">"https://api.stellar-tipjar.com/api/v2/tips"</span>, {
+  method: <span class="str">"POST"</span>,
+  headers: {
+    <span class="str">"Content-Type"</span>: <span class="str">"application/json"</span>,
+    <span class="str">"Authorization"</span>: <span class="str">`Bearer ${accessToken}`</span>,
+  },
+  body: JSON.stringify({
+    username: <span class="str">"alice"</span>, amount: <span class="str">"10.5"</span>,
+    transaction_hash: <span class="str">"a1b2c3d4..."</span>,
+    message: <span class="str">"Keep up the great work!"</span>,
+  }),
+});
+<span class="kw">const</span> tip = <span class="kw">await</span> resp.json();</code></pre></div>
+  <div class="panel"><pre><code><span class="kw">let</span> resp = client
+    .post(<span class="str">"https://api.stellar-tipjar.com/api/v2/tips"</span>)
+    .bearer_auth(&amp;access_token)
+    .json(&amp;serde_json::json!({
+        <span class="str">"username"</span>: <span class="str">"alice"</span>, <span class="str">"amount"</span>: <span class="str">"10.5"</span>,
+        <span class="str">"transaction_hash"</span>: <span class="str">"a1b2c3d4..."</span>,
+        <span class="str">"message"</span>: <span class="str">"Keep up the great work!"</span>,
+    }))
+    .send().await?;</code></pre></div>
+
+  <!-- List creator tips -->
+  <h3><span class="pill GET">GET</span> List creator tips (paginated)</h3>
+  <div class="tabs" id="list">
+    <button class="tab active" onclick="sw('list',0)">cURL</button>
+    <button class="tab" onclick="sw('list',1)">Python</button>
+    <button class="tab" onclick="sw('list',2)">JavaScript</button>
+  </div>
+  <div class="panel active"><pre><code>curl "https://api.stellar-tipjar.com/api/v2/creators/alice/tips?page=1&limit=20"</code></pre></div>
+  <div class="panel"><pre><code>resp = requests.get(
+    <span class="str">"https://api.stellar-tipjar.com/api/v2/creators/alice/tips"</span>,
+    params={<span class="str">"page"</span>: <span class="nm">1</span>, <span class="str">"limit"</span>: <span class="nm">20</span>},
+)
+data = resp.json()  <span class="cm"># { data, total, page, limit, total_pages, has_next, has_prev }</span></code></pre></div>
+  <div class="panel"><pre><code><span class="kw">const</span> resp = <span class="kw">await</span> fetch(
+  <span class="str">"https://api.stellar-tipjar.com/api/v2/creators/alice/tips?page=1&amp;limit=20"</span>
+);
+<span class="kw">const</span> { data, total, has_next } = <span class="kw">await</span> resp.json();</code></pre></div>
+
+  <h2>SDK Generation</h2>
+  <p>Generate a typed client from the OpenAPI spec using <a href="https://openapi-generator.tech">openapi-generator</a>:</p>
+  <h3>TypeScript</h3>
+  <pre><code>npx @openapitools/openapi-generator-cli generate \
+  -i https://api.stellar-tipjar.com/docs/openapi.json \
+  -g typescript-fetch \
+  -o ./sdk/typescript \
+  --additional-properties=typescriptThreePlus=true</code></pre>
+  <h3>Python</h3>
+  <pre><code>openapi-generator generate \
+  -i https://api.stellar-tipjar.com/docs/openapi.json \
+  -g python \
+  -o ./sdk/python \
+  --additional-properties=packageName=stellar_tipjar</code></pre>
+  <h3>Go</h3>
+  <pre><code>openapi-generator generate \
+  -i https://api.stellar-tipjar.com/docs/openapi.json \
+  -g go \
+  -o ./sdk/go \
+  --additional-properties=packageName=stellartipjar</code></pre>
+
+  <h2>Endpoint Reference</h2>
+  <table>
+    <tr><th>Method</th><th>Path</th><th>Auth</th><th>Description</th></tr>
+    <tr><td><span class="pill GET">GET</span></td><td><code>/health</code></td><td>—</td><td>Liveness probe</td></tr>
+    <tr><td><span class="pill GET">GET</span></td><td><code>/ready</code></td><td>—</td><td>Readiness probe</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/auth/register</code></td><td>—</td><td>Register a new creator</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/auth/login</code></td><td>—</td><td>Login, receive JWT pair</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/auth/refresh</code></td><td>—</td><td>Refresh access token</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/auth/2fa/setup</code></td><td>Bearer</td><td>Initiate TOTP 2FA setup</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/auth/2fa/verify</code></td><td>Bearer</td><td>Verify and enable 2FA</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/auth/2fa/recover</code></td><td>—</td><td>Account recovery with backup code</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/creators</code></td><td>—</td><td>Create creator profile</td></tr>
+    <tr><td><span class="pill GET">GET</span></td><td><code>/api/v2/creators/{username}</code></td><td>—</td><td>Get creator by username</td></tr>
+    <tr><td><span class="pill GET">GET</span></td><td><code>/api/v2/creators/{username}/tips</code></td><td>—</td><td>List creator tips (paginated)</td></tr>
+    <tr><td><span class="pill GET">GET</span></td><td><code>/api/v2/creators/search</code></td><td>—</td><td>Search creators</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/tips</code></td><td>Bearer</td><td>Record a verified tip</td></tr>
+    <tr><td><span class="pill GET">GET</span></td><td><code>/api/v2/tips</code></td><td>—</td><td>List all tips (paginated)</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/tips/{id}/report</code></td><td>—</td><td>Report tip message</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/teams</code></td><td>Bearer</td><td>Create team</td></tr>
+    <tr><td><span class="pill GET">GET</span></td><td><code>/api/v2/teams/{id}/splits</code></td><td>Bearer</td><td>Tip split history</td></tr>
+    <tr><td><span class="pill POST">POST</span></td><td><code>/api/v2/tenants</code></td><td>Bearer</td><td>Provision tenant</td></tr>
+    <tr><td><span class="pill GET">GET</span></td><td><code>/api/v2/tenants/{id}/analytics</code></td><td>Bearer</td><td>Tenant analytics</td></tr>
+    <tr><td><span class="pill GET">GET</span></td><td><code>/api/v2/tenants/{id}/usage</code></td><td>Bearer</td><td>Tenant resource usage</td></tr>
+  </table>
+
+  <h2>Rate Limits</h2>
+  <table>
+    <tr><th>Tier</th><th>Limit</th><th>Applies to</th></tr>
+    <tr><td>Read</td><td>120 req/min per IP</td><td>GET endpoints</td></tr>
+    <tr><td>Write</td><td>30 req/min per IP</td><td>POST / PUT / DELETE</td></tr>
+  </table>
+  <p>HTTP <code>429 Too Many Requests</code> is returned when exceeded. Check the <code>Retry-After</code> header.</p>
+
+  <h2>Error Format</h2>
+  <p>All errors use a consistent JSON envelope:</p>
+  <pre><code>{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Human-readable description",
+    "details": {}
+  }
+}</code></pre>
+</div>
+<script>
+function sw(id, idx) {
+  const group = document.getElementById(id);
+  group.querySelectorAll('.tab').forEach((t, i) => t.classList.toggle('active', i === idx));
+  let panels = [], el = group.nextElementSibling;
+  while (el && el.classList.contains('panel')) { panels.push(el); el = el.nextElementSibling; }
+  panels.forEach((p, i) => p.classList.toggle('active', i === idx));
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
closes #295 
- Add /docs route serving Redoc interactive reference portal
- Add /docs/sdk route with SDK quickstart guide and tabbed code samples (cURL, Python, JavaScript, Rust) for all core flows
- Add /docs/openapi.json endpoint serving the live spec
- Enrich OpenAPI info: servers block, rate limit table, error format, links to portal and SDK guide
- HTML assets inlined via include_str! in static/docs/
- Wire portal router into both lib.rs app builder and main.rs