### PR TITLE
feat(health): add comprehensive health check with dependency status

### DIFF
--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,150 +1,274 @@
 use crate::db::connection::AppState;
-use crate::db::health::check_db;
 use crate::services::circuit_breaker::CircuitState;
 use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
-use serde_json::json;
+use serde::Serialize;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::timeout;
 
-/// Liveness probe — checks DB connectivity and circuit-breaker state
+const CHECK_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DepStatus {
+    Ok,
+    Degraded,
+    Unreachable,
+    NotConfigured,
+}
+
+#[derive(Serialize)]
+struct DepDetail {
+    status: DepStatus,
+    latency_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    dependencies: Dependencies,
+}
+
+#[derive(Serialize)]
+struct Dependencies {
+    postgres: DepDetail,
+    redis: DepDetail,
+    stellar: DepDetail,
+}
+
+/// Liveness + dependency health — GET /health
+///
+/// Returns 200 when all dependencies are healthy, 207 when any non-critical
+/// dependency is degraded, 503 when postgres (critical) is unreachable.
 #[utoipa::path(
     get,
     path = "/health",
     tag = "health",
     responses(
-        (status = 200, description = "Service is healthy",
-         example = json!({ "status": "ok", "db": "connected" })),
-        (status = 503, description = "Service degraded",
-         example = json!({ "status": "degraded", "db": "circuit_open" }))
+        (status = 200, description = "All dependencies healthy"),
+        (status = 207, description = "One or more non-critical dependencies degraded"),
+        (status = 503, description = "Critical dependency (postgres) unreachable"),
     )
 )]
 pub async fn health_check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let cb_state = state.db_circuit_breaker.state();
-    let cb_open = cb_state == CircuitState::Open;
+    let (postgres, redis, stellar) = tokio::join!(
+        check_postgres(&state),
+        check_redis(&state),
+        check_stellar(&state),
+    );
 
-    if cb_open {
-        tracing::warn!("Health check: DB circuit breaker is OPEN");
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "status": "degraded", "db": "circuit_open" })),
-        )
-            .into_response();
-    }
+    let postgres_ok = matches!(postgres.status, DepStatus::Ok);
+    let all_ok = postgres_ok
+        && matches!(redis.status, DepStatus::Ok | DepStatus::NotConfigured)
+        && matches!(stellar.status, DepStatus::Ok);
 
-    match check_db(&state.db).await {
-        Ok(_) => {
-            state.db_circuit_breaker.record_success();
-            let pool = &state.db;
-            (
-                StatusCode::OK,
-                Json(json!({
-                    "status": "ok",
-                    "db": "connected",
-                    "pool": {
-                        "size": pool.size(),
-                        "idle": pool.num_idle(),
-                    },
-                    "circuit_breaker": format!("{:?}", cb_state),
-                })),
-            )
-                .into_response()
-        }
-        Err(e) => {
-            state.db_circuit_breaker.record_failure();
-            tracing::error!("Database health check failed: {:?}", e);
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(json!({ "status": "degraded", "db": "unreachable" })),
-            )
-                .into_response()
-        }
-    }
+    let (http_status, label) = if !postgres_ok {
+        (StatusCode::SERVICE_UNAVAILABLE, "unhealthy")
+    } else if all_ok {
+        (StatusCode::OK, "ok")
+    } else {
+        (StatusCode::MULTI_STATUS, "degraded")
+    };
+
+    (
+        http_status,
+        Json(HealthResponse {
+            status: label,
+            dependencies: Dependencies { postgres, redis, stellar },
+        }),
+    )
+        .into_response()
 }
 
-/// Readiness probe — checks DB, Stellar network, and Redis
+/// Readiness probe — GET /ready
+///
+/// Returns 200 only when postgres (the critical dependency) is reachable.
+/// Load balancers should use this endpoint to gate traffic.
 #[utoipa::path(
     get,
     path = "/ready",
     tag = "health",
     responses(
-        (status = 200, description = "All dependencies reachable",
-         example = json!({ "status": "ready", "checks": { "db": "ok", "stellar": "ok", "redis": "ok" } })),
-        (status = 503, description = "One or more dependencies unreachable",
-         example = json!({ "status": "not_ready", "checks": { "db": "unreachable", "stellar": "ok", "redis": "not_configured" } }))
+        (status = 200, description = "Service is ready to accept traffic"),
+        (status = 503, description = "Service is not ready (postgres unreachable)"),
     )
 )]
 pub async fn readiness_check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let mut all_ok = true;
-    let mut checks = serde_json::Map::new();
+    let postgres = check_postgres(&state).await;
 
-    // --- Database ---
-    match check_db(&state.db).await {
-        Ok(_) => {
-            checks.insert("db".into(), json!("ok"));
-        }
-        Err(e) => {
-            tracing::error!("Readiness: DB check failed: {:?}", e);
-            checks.insert("db".into(), json!("unreachable"));
-            all_ok = false;
-        }
+    if matches!(postgres.status, DepStatus::Ok) {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({ "status": "ready" })),
+        )
+            .into_response()
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "status": "not_ready",
+                "reason": postgres.error.as_deref().unwrap_or("postgres unreachable"),
+            })),
+        )
+            .into_response()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-dependency checks, each capped at CHECK_TIMEOUT (2 s)
+// ---------------------------------------------------------------------------
+
+async fn check_postgres(state: &AppState) -> DepDetail {
+    // Respect circuit breaker — avoid hammering a dead DB
+    if state.db_circuit_breaker.state() == CircuitState::Open {
+        return DepDetail {
+            status: DepStatus::Unreachable,
+            latency_ms: None,
+            error: Some("circuit breaker open".into()),
+            detail: None,
+        };
     }
 
-    // --- Stellar network (Horizon ping) ---
+    let pool = &state.db;
+    let t = Instant::now();
+
+    match timeout(CHECK_TIMEOUT, sqlx::query("SELECT 1").execute(pool)).await {
+        Ok(Ok(_)) => {
+            state.db_circuit_breaker.record_success();
+            DepDetail {
+                status: DepStatus::Ok,
+                latency_ms: Some(t.elapsed().as_millis() as u64),
+                error: None,
+                detail: Some(serde_json::json!({
+                    "pool_size":  pool.size(),
+                    "pool_idle":  pool.num_idle(),
+                })),
+            }
+        }
+        Ok(Err(e)) => {
+            state.db_circuit_breaker.record_failure();
+            tracing::error!(error = %e, "Postgres health check failed");
+            DepDetail {
+                status: DepStatus::Unreachable,
+                latency_ms: Some(t.elapsed().as_millis() as u64),
+                error: Some(e.to_string()),
+                detail: None,
+            }
+        }
+        Err(_) => {
+            state.db_circuit_breaker.record_failure();
+            tracing::error!("Postgres health check timed out after 2s");
+            DepDetail {
+                status: DepStatus::Unreachable,
+                latency_ms: Some(CHECK_TIMEOUT.as_millis() as u64),
+                error: Some("timed out after 2s".into()),
+                detail: None,
+            }
+        }
+    }
+}
+
+async fn check_redis(state: &AppState) -> DepDetail {
+    let Some(redis) = &state.redis else {
+        return DepDetail {
+            status: DepStatus::NotConfigured,
+            latency_ms: None,
+            error: None,
+            detail: None,
+        };
+    };
+
+    let mut conn = redis.clone();
+    let t = Instant::now();
+
+    match timeout(
+        CHECK_TIMEOUT,
+        redis::cmd("PING").query_async::<String>(&mut conn),
+    )
+    .await
+    {
+        Ok(Ok(_)) => DepDetail {
+            status: DepStatus::Ok,
+            latency_ms: Some(t.elapsed().as_millis() as u64),
+            error: None,
+            detail: None,
+        },
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "Redis health check failed");
+            DepDetail {
+                status: DepStatus::Unreachable,
+                latency_ms: Some(t.elapsed().as_millis() as u64),
+                error: Some(e.to_string()),
+                detail: None,
+            }
+        }
+        Err(_) => {
+            tracing::warn!("Redis health check timed out after 2s");
+            DepDetail {
+                status: DepStatus::Degraded,
+                latency_ms: Some(CHECK_TIMEOUT.as_millis() as u64),
+                error: Some("timed out after 2s".into()),
+                detail: None,
+            }
+        }
+    }
+}
+
+async fn check_stellar(state: &AppState) -> DepDetail {
     let horizon_base = if state.stellar.network == "mainnet" {
         "https://horizon.stellar.org"
     } else {
         "https://horizon-testnet.stellar.org"
     };
-    match reqwest::Client::new()
-        .get(horizon_base)
-        .timeout(std::time::Duration::from_secs(5))
-        .send()
-        .await
-    {
-        Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 200 => {
-            checks.insert("stellar".into(), json!("ok"));
-        }
-        Ok(resp) => {
-            tracing::warn!("Readiness: Stellar returned {}", resp.status());
-            checks.insert("stellar".into(), json!(format!("degraded ({})", resp.status())));
-        }
-        Err(e) => {
-            tracing::error!("Readiness: Stellar check failed: {:?}", e);
-            checks.insert("stellar".into(), json!("unreachable"));
-            all_ok = false;
-        }
-    }
 
-    // --- Redis ---
-    match &state.redis {
-        Some(redis) => {
-            let mut conn = redis.clone();
-            match redis::cmd("PING")
-                .query_async::<String>(&mut conn)
-                .await
-            {
-                Ok(_) => {
-                    checks.insert("redis".into(), json!("ok"));
-                }
-                Err(e) => {
-                    tracing::error!("Readiness: Redis check failed: {:?}", e);
-                    checks.insert("redis".into(), json!("unreachable"));
-                    all_ok = false;
-                }
+    let t = Instant::now();
+
+    let req = reqwest::Client::new()
+        .get(horizon_base)
+        .timeout(CHECK_TIMEOUT)
+        .send();
+
+    match timeout(CHECK_TIMEOUT, req).await {
+        Ok(Ok(resp)) if resp.status().is_success() || resp.status().as_u16() == 200 => {
+            DepDetail {
+                status: DepStatus::Ok,
+                latency_ms: Some(t.elapsed().as_millis() as u64),
+                error: None,
+                detail: None,
             }
         }
-        None => {
-            checks.insert("redis".into(), json!("not_configured"));
+        Ok(Ok(resp)) => {
+            tracing::warn!(status = %resp.status(), "Stellar Horizon returned non-200");
+            DepDetail {
+                status: DepStatus::Degraded,
+                latency_ms: Some(t.elapsed().as_millis() as u64),
+                error: Some(format!("HTTP {}", resp.status())),
+                detail: None,
+            }
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "Stellar health check failed");
+            DepDetail {
+                status: DepStatus::Unreachable,
+                latency_ms: Some(t.elapsed().as_millis() as u64),
+                error: Some(e.to_string()),
+                detail: None,
+            }
+        }
+        Err(_) => {
+            tracing::warn!("Stellar health check timed out after 2s");
+            DepDetail {
+                status: DepStatus::Degraded,
+                latency_ms: Some(CHECK_TIMEOUT.as_millis() as u64),
+                error: Some("timed out after 2s".into()),
+                detail: None,
+            }
         }
     }
-
-    let status = if all_ok { "ready" } else { "not_ready" };
-    let code = if all_ok {
-        StatusCode::OK
-    } else {
-        StatusCode::SERVICE_UNAVAILABLE
-    };
-
-    (code, Json(json!({ "status": status, "checks": checks }))).into_response()
 }
 
 pub fn router() -> Router<Arc<AppState>> {


### PR DESCRIPTION
closes #316

- GET /health checks postgres, redis, and stellar with 2s timeouts
- Returns 200 (all ok), 207 (degraded), or 503 (postgres unreachable)
- Each dependency reports status, latency_ms, and optional error detail
- Postgres check uses SELECT 1, respects circuit breaker state
- Redis check skips gracefully when not configured (not_configured)
- Stellar checks Horizon endpoint; timeout yields degraded not 503
- GET /ready returns 200 only when postgres is healthy (critical path)
- All three checks run concurrently via tokio::join!