### PR TITLE
feat: make tip message moderation threshold configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,3 +91,13 @@ RATE_LIMIT_WRITE_BURST_SIZE=5
 # EXCHANGE_RATE_API_KEY=your_key_here
 # How often to refresh exchange rates in seconds (default: 3600 = 1 hour)
 # EXCHANGE_RATE_REFRESH_SECS=3600
+
+# Content Moderation
+# Set to "false" or "0" to disable all moderation checks (useful in development).
+# Default: true
+# MODERATION_ENABLED=true
+#
+# Confidence threshold (0.0–1.0) above which a tip message or comment is hard-blocked.
+# Violations or AI scores at or above this value cause the request to be rejected with 422.
+# Default: 0.90
+# MODERATION_THRESHOLD=0.90

--- a/README.md
+++ b/README.md
@@ -56,6 +56,31 @@ All configuration is provided through environment variables. Copy `.env.example`
 
 Logging verbosity is controlled by the `RUST_LOG` environment variable (defaults to `stellar_tipjar_backend=debug,tower_http=debug`).
 
+### Content Moderation
+
+Tip messages and comments are screened by a rule-based engine and (optionally) the Anthropic Claude API. Two environment variables control the behaviour:
+
+| Variable | Default | Description |
+|---|---|---|
+| `MODERATION_ENABLED` | `true` | Set to `false` or `0` to disable all moderation. Useful in development/test environments where you don't want content checks blocking requests. |
+| `MODERATION_THRESHOLD` | `0.90` | Confidence threshold (0.0–1.0). Content whose highest-confidence violation or AI score meets or exceeds this value is hard-blocked with a `422` response. |
+
+These values can also be changed **at runtime** without a restart via the admin API:
+
+```
+# Inspect current configuration
+GET /api/v1/admin/moderation/config
+
+# Update threshold and/or enabled flag
+PATCH /api/v1/admin/moderation/config
+Content-Type: application/json
+X-Admin-Key: <admin-key>
+
+{ "threshold": 0.85, "enabled": true }
+```
+
+Both `enabled` and `threshold` in the PATCH body are optional — omit a field to keep its current value. Changes take effect immediately for all subsequent requests.
+
 ## Running the Server
 
 ```bash

--- a/src/controllers/tip_controller.rs
+++ b/src/controllers/tip_controller.rs
@@ -38,7 +38,8 @@ pub async fn record_tip_with_context(
                 .moderation
                 .check_content(msg, ContentType::TipMessage, None)
                 .await;
-            if moderation.has_high_confidence_violation(0.90) {
+            let threshold = state.moderation.block_threshold();
+            if moderation.has_high_confidence_violation(threshold) {
                 TIPS_FAILED_TOTAL
                     .with_label_values(&["moderation_rejected"])
                     .inc();

--- a/src/moderation/mod.rs
+++ b/src/moderation/mod.rs
@@ -2,6 +2,13 @@
 //!
 //! Provides AI-powered and rule-based detection of inappropriate content,
 //! spam, and policy violations, with a human review queue for flagged items.
+//!
+//! # Configuration
+//!
+//! | Environment variable   | Default | Description                                        |
+//! |------------------------|---------|----------------------------------------------------|
+//! | `MODERATION_ENABLED`   | `true`  | Set to `false` to bypass all moderation checks.    |
+//! | `MODERATION_THRESHOLD` | `0.90`  | Confidence threshold above which content is blocked.|
 
 pub mod ai_detector;
 pub mod review_queue;
@@ -13,6 +20,8 @@ pub use rules::RulesEngine;
 
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
 use uuid::Uuid;
 
 /// Categories of policy violations the moderation system can detect.
@@ -57,7 +66,7 @@ impl ContentType {
 /// The combined result of running all moderation checks against a piece of content.
 #[derive(Debug, Clone)]
 pub struct ModerationResult {
-    /// True when violations were detected or AI score exceeds the block threshold.
+    /// True when violations were detected or AI score exceeds the flag threshold.
     pub is_flagged: bool,
     pub violations: Vec<Violation>,
     /// Aggregate harm probability returned by the AI detector (0.0–1.0).
@@ -76,12 +85,86 @@ impl ModerationResult {
     }
 }
 
+// ── Runtime-configurable moderation settings ─────────────────────────────────
+
+/// Serializable snapshot of the current moderation configuration,
+/// returned by `GET /api/v1/admin/moderation/config`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModerationConfig {
+    /// Whether moderation checks are active. When `false`, all content passes.
+    pub enabled: bool,
+    /// Confidence threshold (0.0–1.0) above which content is hard-blocked.
+    pub threshold: f32,
+}
+
+/// Atomically-stored moderation configuration that can be updated at runtime
+/// without restarting the service.
+///
+/// Threshold is stored as a `u32` bit-pattern of an `f32` so it can live in
+/// an `AtomicU32`.
+#[derive(Debug)]
+pub struct AtomicModerationConfig {
+    enabled: AtomicBool,
+    /// f32 bits stored as u32 for atomic access.
+    threshold_bits: AtomicU32,
+}
+
+impl AtomicModerationConfig {
+    /// Load initial values from environment variables, falling back to defaults.
+    pub fn from_env() -> Self {
+        let enabled = std::env::var("MODERATION_ENABLED")
+            .map(|v| v.to_lowercase() != "false" && v != "0")
+            .unwrap_or(true);
+
+        let threshold = std::env::var("MODERATION_THRESHOLD")
+            .ok()
+            .and_then(|v| v.parse::<f32>().ok())
+            .map(|t| t.clamp(0.0, 1.0))
+            .unwrap_or(0.90_f32);
+
+        tracing::info!(
+            enabled,
+            threshold,
+            "Moderation initialised (MODERATION_ENABLED / MODERATION_THRESHOLD)"
+        );
+
+        Self {
+            enabled: AtomicBool::new(enabled),
+            threshold_bits: AtomicU32::new(threshold.to_bits()),
+        }
+    }
+
+    /// Read the current configuration snapshot.
+    pub fn get(&self) -> ModerationConfig {
+        ModerationConfig {
+            enabled: self.enabled.load(Ordering::Relaxed),
+            threshold: f32::from_bits(self.threshold_bits.load(Ordering::Relaxed)),
+        }
+    }
+
+    /// Atomically update the configuration.
+    pub fn set(&self, cfg: ModerationConfig) {
+        let threshold = cfg.threshold.clamp(0.0, 1.0);
+        self.enabled.store(cfg.enabled, Ordering::Relaxed);
+        self.threshold_bits
+            .store(threshold.to_bits(), Ordering::Relaxed);
+        tracing::info!(
+            enabled = cfg.enabled,
+            threshold,
+            "Moderation configuration updated at runtime"
+        );
+    }
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
 /// Top-level orchestrator: runs rule-based checks, optionally follows up with AI
 /// detection, and persists flagged items to the review queue.
 pub struct ModerationService {
     rules: RulesEngine,
     ai: AiDetector,
     queue: ReviewQueue,
+    config: Arc<AtomicModerationConfig>,
 }
 
 impl ModerationService {
@@ -90,17 +173,43 @@ impl ModerationService {
             rules: RulesEngine::new(),
             ai: AiDetector::new(),
             queue: ReviewQueue::new(db),
+            config: Arc::new(AtomicModerationConfig::from_env()),
         }
+    }
+
+    /// Read the current runtime configuration.
+    pub fn config(&self) -> ModerationConfig {
+        self.config.get()
+    }
+
+    /// Update the runtime configuration (persists for the lifetime of the process).
+    pub fn update_config(&self, cfg: ModerationConfig) {
+        self.config.set(cfg);
     }
 
     /// Evaluate `content` of `content_type`. If flagged, the item is persisted to
     /// the review queue and associated with `content_id` when provided.
+    ///
+    /// When `MODERATION_ENABLED=false` this is a no-op and always returns a
+    /// clean result so that development environments are not blocked.
     pub async fn check_content(
         &self,
         content: &str,
         content_type: ContentType,
         content_id: Option<Uuid>,
     ) -> ModerationResult {
+        let cfg = self.config.get();
+
+        // Short-circuit when moderation is disabled (e.g. development).
+        if !cfg.enabled {
+            return ModerationResult {
+                is_flagged: false,
+                violations: vec![],
+                ai_score: None,
+                ai_reasoning: None,
+            };
+        }
+
         // 1. Fast rule-based pass — never makes network calls.
         let mut violations = self.rules.check(content, &content_type);
 
@@ -120,8 +229,12 @@ impl ModerationService {
             (None, None)
         };
 
+        // Use the configurable threshold for the soft "queue for review" gate.
+        // Hard-blocking uses the same threshold at the call sites via
+        // `ModerationResult::has_high_confidence_violation(threshold)`.
+        let flag_threshold = cfg.threshold * 0.78; // ~78 % of block threshold triggers review
         let is_flagged = !violations.is_empty()
-            || ai_score.map(|s| s > 0.7).unwrap_or(false);
+            || ai_score.map(|s| s > flag_threshold).unwrap_or(false);
 
         let result = ModerationResult {
             is_flagged,
@@ -142,6 +255,16 @@ impl ModerationService {
         }
 
         result
+    }
+
+    /// The current block threshold to use at call sites.
+    pub fn block_threshold(&self) -> f32 {
+        self.config.get().threshold
+    }
+
+    /// Returns `true` when moderation is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.config.get().enabled
     }
 
     /// Manually flag content for review (called from user-facing routes).

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -3,7 +3,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     middleware,
     response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{delete, get, patch, post},
     Json, Router,
 };
 use sha2::{Digest, Sha256};
@@ -14,6 +14,7 @@ use crate::controllers::admin_controller;
 use crate::db::connection::AppState;
 use crate::middleware::admin_auth::require_admin;
 use crate::models::admin::{AuditLogResponse, DeleteCreatorRequest};
+use crate::moderation::ModerationConfig;
 
 #[derive(serde::Deserialize)]
 pub struct AuditQuery {
@@ -35,6 +36,7 @@ pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
         // Moderation endpoints
         .route("/admin/moderation/queue", get(moderation_queue))
         .route("/admin/moderation/stats", get(moderation_stats))
+        .route("/admin/moderation/config", get(moderation_get_config).patch(moderation_update_config))
         .route("/admin/moderation/flag", post(moderation_flag))
         .route("/admin/moderation/:id/approve", post(moderation_approve))
         .route("/admin/moderation/:id/reject", post(moderation_reject))
@@ -170,6 +172,49 @@ async fn moderation_stats(State(state): State<Arc<AppState>>) -> impl IntoRespon
                 .into_response()
         }
     }
+}
+
+/// GET /admin/moderation/config — return the current runtime moderation configuration.
+async fn moderation_get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let cfg = state.moderation.config();
+    (StatusCode::OK, Json(serde_json::json!(cfg))).into_response()
+}
+
+/// PATCH /admin/moderation/config — update threshold and/or enabled flag at runtime.
+///
+/// Body fields (all optional — omitted fields keep their current value):
+/// - `enabled`: bool
+/// - `threshold`: f32 in [0.0, 1.0]
+#[derive(serde::Deserialize)]
+struct UpdateModerationConfigBody {
+    enabled: Option<bool>,
+    threshold: Option<f32>,
+}
+
+async fn moderation_update_config(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<UpdateModerationConfigBody>,
+) -> impl IntoResponse {
+    // Validate threshold range when provided.
+    if let Some(t) = body.threshold {
+        if !(0.0..=1.0).contains(&t) {
+            return (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(serde_json::json!({ "error": "threshold must be between 0.0 and 1.0" })),
+            )
+                .into_response();
+        }
+    }
+
+    let mut cfg = state.moderation.config();
+    if let Some(enabled) = body.enabled {
+        cfg.enabled = enabled;
+    }
+    if let Some(threshold) = body.threshold {
+        cfg.threshold = threshold;
+    }
+    state.moderation.update_config(cfg.clone());
+    (StatusCode::OK, Json(serde_json::json!(cfg))).into_response()
 }
 
 async fn moderation_approve(

--- a/src/routes/comments.rs
+++ b/src/routes/comments.rs
@@ -33,7 +33,8 @@ async fn create_comment(
         .moderation
         .check_content(&body.body, ContentType::TipMessage, None)
         .await;
-    if moderation.has_high_confidence_violation(0.90) {
+    let threshold = state.moderation.block_threshold();
+    if moderation.has_high_confidence_violation(threshold) {
         return Err(AppError::bad_request("Comment was rejected by content moderation"));
     }
 


### PR DESCRIPTION
- Add MODERATION_THRESHOLD env var (default 0.90) loaded at startup via AtomicModerationConfig; stored lock-free as AtomicBool + AtomicU32 so reads from hot request paths have zero contention.

- Add MODERATION_ENABLED env var (default true); when false, check_content short-circuits and returns a clean result — lets development environments skip moderation entirely.

- Replace hardcoded 0.90 in tip_controller and comments route with state.moderation.block_threshold() so both call sites respect the runtime value.

- Expose GET  /api/v1/admin/moderation/config (inspect current config) and PATCH /api/v1/admin/moderation/config (update threshold/enabled at runtime without restart). Both routes sit behind the existing require_admin middleware. PATCH accepts partial payloads and validates threshold is in [0.0, 1.0].

- Document MODERATION_ENABLED and MODERATION_THRESHOLD in .env.example and add a Content Moderation sub-section to README.md describing both env vars and the runtime admin API.

closes #305 