### PR TITLE
feat: request body size limit and content-type validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tower-http = { version = "0.5", features = ["cors", "timeout", "trace", "compression-gzip", "request-id"] }
+tower-http = { version = "0.5", features = ["cors", "timeout", "trace", "compression-gzip", "request-id", "limit"] }
 tower_governor = { version = "0.4", features = ["axum"] }
 governor = "0.6"
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
@@ -71,7 +71,7 @@ tracing-opentelemetry = "0.23"
 hostname = "0.4"
 
 [dev-dependencies]
-axum-test = "0.5"
+axum-test = "20"
 tokio = { version = "1", features = ["full"] }
 tower = "0.4"
 httpmock = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub fn create_app(state: Arc<AppState>) -> Router {
     let general_limiter = middleware::rate_limiter::general_limiter();
     let write_limiter = middleware::rate_limiter::write_limiter();
 
-    // Write endpoints get a stricter per-IP limit.
+    // Write endpoints get a stricter per-IP limit and JSON content-type enforcement.
     let write_routes = Router::new()
         .merge(routes::auth::router())
         .merge(routes::teams::router())
@@ -77,6 +77,9 @@ pub fn create_app(state: Arc<AppState>) -> Router {
         .merge(routes::goals::router())
         .merge(routes::refunds::public_router())
         .merge(routes::tx_pool::router())
+        .layer(axum::middleware::from_fn(
+            middleware::body_limit::require_json_content_type,
+        ))
         .layer(write_limiter);
 
     // Read endpoints use the general limit and intelligent response caching.
@@ -123,5 +126,6 @@ pub fn create_app(state: Arc<AppState>) -> Router {
             Arc::clone(&state),
             middleware::usage_tracker::track_api_usage,
         ))
+        .layer(middleware::body_limit::body_limit_layer_from_env())
         .with_state(state)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,9 @@ async fn main() -> anyhow::Result<()> {
                         .merge(routes::scheduled_tips::router())
                         .merge(routes::tx_pool::router())
                         .merge(routes::v1::router())
+                        .layer(axum::middleware::from_fn(
+                            middleware::body_limit::require_json_content_type,
+                        ))
                         .layer(write_limiter_v1),
                 )
                 .merge(
@@ -416,6 +419,9 @@ async fn main() -> anyhow::Result<()> {
                     .merge(routes::scheduled_tips::router())
                     .merge(routes::tx_pool::router())
                     .merge(routes::v2::router())
+                    .layer(axum::middleware::from_fn(
+                        middleware::body_limit::require_json_content_type,
+                    ))
                     .layer(write_limiter_v2),
             )
             .merge(
@@ -490,6 +496,7 @@ async fn main() -> anyhow::Result<()> {
         ))
         .layer(axum::middleware::from_fn(middleware::cache::cache_control))
         .layer(middleware::timeout::timeout_layer_from_env())
+        .layer(middleware::body_limit::body_limit_layer_from_env())
         // Redis distributed throttle (shared across instances, fail-open when Redis unavailable).
         .layer(axum::middleware::from_fn(
             middleware::rate_limiter::redis_throttle_middleware,

--- a/src/middleware/body_limit.rs
+++ b/src/middleware/body_limit.rs
@@ -1,0 +1,180 @@
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use tower_http::limit::RequestBodyLimitLayer;
+
+/// Default maximum request body size: 1 MiB.
+pub const DEFAULT_BODY_LIMIT_BYTES: usize = 1024 * 1024;
+
+/// Returns a [`RequestBodyLimitLayer`] sized from the `MAX_REQUEST_BODY_BYTES`
+/// environment variable, falling back to [`DEFAULT_BODY_LIMIT_BYTES`] (1 MiB).
+///
+/// Oversized bodies cause axum's extractors (`Json`, `Bytes`, `String`) to
+/// return **413 Payload Too Large** automatically.
+pub fn body_limit_layer_from_env() -> RequestBodyLimitLayer {
+    let limit = std::env::var("MAX_REQUEST_BODY_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_BODY_LIMIT_BYTES);
+    tracing::debug!(limit_bytes = limit, "body size limit configured");
+    RequestBodyLimitLayer::new(limit)
+}
+
+/// Middleware that rejects write requests whose `Content-Type` is not
+/// `application/json` with **415 Unsupported Media Type**.
+///
+/// Only POST, PUT, and PATCH requests are inspected; all other methods pass
+/// through. Apply this to API routers that exclusively consume JSON.
+pub async fn require_json_content_type(req: Request<Body>, next: Next) -> Response {
+    if matches!(*req.method(), Method::POST | Method::PUT | Method::PATCH) {
+        let content_type = req
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        if !content_type.contains("application/json") {
+            return (
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                axum::Json(serde_json::json!({
+                    "error": "Unsupported Media Type",
+                    "code": "UNSUPPORTED_MEDIA_TYPE",
+                    "status": 415,
+                    "details": { "required": "application/json" }
+                })),
+            )
+                .into_response();
+        }
+    }
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, middleware, routing::post, Json, Router};
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    async fn json_echo(Json(body): Json<serde_json::Value>) -> Json<serde_json::Value> {
+        Json(body)
+    }
+
+    fn limited_app(limit: usize) -> Router {
+        Router::new()
+            .route("/echo", post(json_echo))
+            .layer(tower_http::limit::RequestBodyLimitLayer::new(limit))
+    }
+
+    fn content_type_app() -> Router {
+        Router::new()
+            .route("/data", post(|| async { StatusCode::OK }))
+            .layer(middleware::from_fn(require_json_content_type))
+    }
+
+    async fn post_request(app: Router, uri: &str, content_type: &str, body: impl Into<Body>) -> StatusCode {
+        app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", content_type)
+                .body(body.into())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
+    }
+
+    #[tokio::test]
+    async fn normal_json_body_passes() {
+        let app = limited_app(1024 * 1024);
+        let payload = serde_json::to_vec(&json!({"hello": "world"})).unwrap();
+        let status = post_request(app, "/echo", "application/json", payload).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn oversized_body_returns_413() {
+        // 64-byte hard limit; the JSON payload will exceed it.
+        let app = limited_app(64);
+        let payload = serde_json::to_vec(&json!({"data": "a".repeat(200)})).unwrap();
+        assert!(payload.len() > 64, "payload must exceed the configured limit");
+        let status = post_request(app, "/echo", "application/json", payload).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn non_json_content_type_returns_415() {
+        let app = content_type_app();
+        let status = post_request(app, "/data", "text/plain", Body::from("hello")).await;
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn missing_content_type_returns_415() {
+        let app = content_type_app();
+        // No content-type header → empty string → not application/json → 415
+        let status = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/data")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status();
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn json_content_type_with_charset_passes() {
+        let app = content_type_app();
+        let status = post_request(app, "/data", "application/json; charset=utf-8", Body::from("{}")).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn get_request_bypasses_content_type_check() {
+        let app = Router::new()
+            .route("/data", axum::routing::get(|| async { StatusCode::OK }))
+            .layer(middleware::from_fn(require_json_content_type));
+        let status = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/data")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status();
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn body_limit_from_env_uses_default() {
+        std::env::remove_var("MAX_REQUEST_BODY_BYTES");
+        let _layer = body_limit_layer_from_env();
+    }
+
+    #[tokio::test]
+    async fn body_limit_from_env_custom_value() {
+        std::env::set_var("MAX_REQUEST_BODY_BYTES", "2097152");
+        let _layer = body_limit_layer_from_env();
+        std::env::remove_var("MAX_REQUEST_BODY_BYTES");
+    }
+
+    #[tokio::test]
+    async fn body_limit_from_env_ignores_invalid_value() {
+        std::env::set_var("MAX_REQUEST_BODY_BYTES", "not-a-number");
+        let _layer = body_limit_layer_from_env(); // must not panic; falls back to default
+        std::env::remove_var("MAX_REQUEST_BODY_BYTES");
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -2,6 +2,7 @@ pub mod admin_auth;
 pub mod api_key_auth;
 pub mod auth;
 pub mod authorization;
+pub mod body_limit;
 pub mod cache;
 pub mod compression;
 pub mod cors;


### PR DESCRIPTION
## Summary

- **Body size limit**: Adds `tower_http::limit::RequestBodyLimitLayer` globally to the router. Default cap is **1 MiB**; oversized bodies cause axum extractors (`Json`, `Bytes`, `String`) to return **413 Payload Too Large**. Configurable via `MAX_REQUEST_BODY_BYTES` env var.
- **Content-Type validation**: Adds `require_json_content_type` middleware rejecting `POST`/`PUT`/`PATCH` requests whose `Content-Type` is not `application/json` with **415 Unsupported Media Type**. Applied only to write-endpoint sub-routers so upload, WebSocket, and GraphQL routes are unaffected.
- **Fixes pre-existing dep breakage**: `axum-test = "0.5"` had no matching version on crates.io; updated to `"20"`.

## Files changed

| File | Change |
|---|---|
| `Cargo.toml` | Add `limit` feature to `tower-http`; fix `axum-test` version |
| `src/middleware/body_limit.rs` | New module: `body_limit_layer_from_env()`, `require_json_content_type`, 9 unit tests |
| `src/middleware/mod.rs` | Register `pub mod body_limit` |
| `src/lib.rs` | Apply both layers in `create_app` |
| `src/main.rs` | Apply both layers to v1/v2 write routers and main app |

## Test plan

- [ ] `cargo test middleware::body_limit` — all 9 unit tests pass
- [ ] Send a >1 MiB POST to any API endpoint → **413**
- [ ] Send `Content-Type: text/plain` to `POST /api/v1/tips` → **415**
- [ ] Set `MAX_REQUEST_BODY_BYTES=5242880` and confirm 5 MiB bodies are accepted
- [ ] GraphQL, WebSocket, and upload routes unaffected

closes #314 