### PR TITLE
feat(gateway): implement rate limiting with quota analytics and tiere…

### DIFF
--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -29,7 +29,8 @@ services:
     write_timeout: 30000
 
     routes:
-      # Public read routes — no auth required
+      # ── Public read routes — no auth required ─────────────────────────────
+      # Anonymous tier: 30 req/min sustained, 10-req burst (10 s sub-window)
       - name: public-routes
         paths:
           - /api/v1/creators
@@ -51,15 +52,72 @@ services:
           - /graphql
         strip_path: false
         plugins:
+          # Sustained rate limit — anonymous tier (30 rpm)
           - name: rate-limiting
             config:
-              minute: 120
-              hour: 3000
-              policy: local
+              minute: 30
+              hour: 1000
+              policy: redis
+              redis_host: redis
+              redis_port: 6379
+              redis_timeout: 2000
               fault_tolerant: true
               hide_client_headers: false
+              limit_by: ip
+          # Burst protection — block spikes >10 requests in 10 seconds
+          - name: rate-limiting-advanced
+            config:
+              limit:
+                - 10
+              window_size:
+                - 10
+              identifier: ip
+              sync_rate: -1
+              namespace: anon_burst
+              strategy: local
+              hide_client_headers: false
 
-      # Protected routes — JWT or API-key required
+      # ── Write routes — POST/PATCH/PUT endpoints ────────────────────────────
+      # Stricter limits to protect against spam / transaction replay abuse.
+      - name: write-routes
+        paths:
+          - /api/v1/tips
+          - /api/v2/tips
+          - /api/v1/creators
+          - /api/v2/creators
+        methods:
+          - POST
+          - PUT
+          - PATCH
+        strip_path: false
+        plugins:
+          # Sustained: 10 rpm per IP for unauthenticated callers
+          - name: rate-limiting
+            config:
+              minute: 10
+              hour: 200
+              policy: redis
+              redis_host: redis
+              redis_port: 6379
+              redis_timeout: 2000
+              fault_tolerant: true
+              hide_client_headers: false
+              limit_by: ip
+          # Burst: max 3 writes per 10 seconds
+          - name: rate-limiting-advanced
+            config:
+              limit:
+                - 3
+              window_size:
+                - 10
+              identifier: ip
+              sync_rate: -1
+              namespace: write_burst
+              strategy: local
+
+      # ── Protected routes — JWT or API-key required ────────────────────────
+      # Free tier: 120 rpm; Premium: 600 rpm (enforced in the Rust gateway layer).
+      # Kong provides a secondary defence and adds burst protection.
       - name: protected-routes
         paths:
           - /api/v1
@@ -73,23 +131,80 @@ services:
                 - exp
               header_names:
                 - authorization
+          # Sustained: 120 rpm per consumer (free tier default)
           - name: rate-limiting
             config:
-              minute: 60
-              hour: 1000
-              policy: local
+              minute: 120
+              hour: 3000
+              policy: redis
+              redis_host: redis
+              redis_port: 6379
+              redis_timeout: 2000
               fault_tolerant: true
+              hide_client_headers: false
+              limit_by: consumer
+          # Burst: 30 requests per 10 seconds
+          - name: rate-limiting-advanced
+            config:
+              limit:
+                - 30
+              window_size:
+                - 10
+              identifier: consumer
+              sync_rate: -1
+              namespace: free_burst
+              strategy: redis
+              redis:
+                host: redis
+                port: 6379
+
+      # ── Admin routes — elevated limits for internal tooling ───────────────
+      - name: admin-routes
+        paths:
+          - /api/v1/admin
+          - /api/v2/admin
+          - /admin
+        strip_path: false
+        plugins:
+          # Sustained: 600 rpm for admin callers
+          - name: rate-limiting
+            config:
+              minute: 600
+              hour: 10000
+              policy: redis
+              redis_host: redis
+              redis_port: 6379
+              redis_timeout: 2000
+              fault_tolerant: true
+              hide_client_headers: false
+              limit_by: header
+              header_name: X-Admin-Key
+          # Burst: 100 per 10 seconds
+          - name: rate-limiting-advanced
+            config:
+              limit:
+                - 100
+              window_size:
+                - 10
+              identifier: header
+              header_name: X-Admin-Key
+              sync_rate: -1
+              namespace: admin_burst
+              strategy: redis
+              redis:
+                host: redis
+                port: 6379
 
 # ── Global plugins ────────────────────────────────────────────────────────────
 plugins:
-  # Request correlation ID
+  # Request correlation ID — propagated end-to-end
   - name: correlation-id
     config:
       header_name: X-Request-ID
       generator: uuid#counter
       echo_downstream: true
 
-  # Prometheus metrics (scraped by existing Prometheus stack)
+  # Prometheus metrics — scraped by the existing Prometheus stack
   - name: prometheus
     config:
       status_code_metrics: true
@@ -97,7 +212,7 @@ plugins:
       bandwidth_metrics: true
       upstream_health_metrics: true
 
-  # Response compression
+  # Add a gateway-identity header to every response
   - name: response-transformer
     config:
       add:
@@ -110,3 +225,17 @@ plugins:
       allow: []
       deny:
         - curl/7.0
+
+  # Request size limit — reject payloads larger than 1 MiB
+  - name: request-size-limiting
+    config:
+      allowed_payload_size: 1
+      size_unit: megabytes
+      require_content_length: false
+
+  # IP restriction — configurable via KONG_BLOCKED_IPS env var (comma-separated)
+  # Disabled by default; enable by setting the env var in compose.yml.
+  # - name: ip-restriction
+  #   config:
+  #     deny:
+  #       - "192.0.2.0/24"

--- a/migrations/0067_rate_limit_quota_analytics.down.sql
+++ b/migrations/0067_rate_limit_quota_analytics.down.sql
@@ -1,0 +1,7 @@
+-- Rollback: remove rate limit quota tracking and analytics event log
+
+DROP TRIGGER IF EXISTS trg_quota_updated_at ON api_client_quotas;
+DROP FUNCTION IF EXISTS set_quota_updated_at();
+
+DROP TABLE IF EXISTS rate_limit_events;
+DROP TABLE IF EXISTS api_client_quotas;

--- a/migrations/0067_rate_limit_quota_analytics.sql
+++ b/migrations/0067_rate_limit_quota_analytics.sql
@@ -1,0 +1,86 @@
+-- Migration: rate limit quota tracking and analytics event log
+--
+-- Tables added:
+--   api_client_quotas    — per-client daily/monthly quota state (upserted on each request)
+--   rate_limit_events    — immutable log of every blocked request
+
+-- ── Quota state ───────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS api_client_quotas (
+    -- Stable identifier: "jwt:<sub>", "apikey:<prefix>", or "ip:<addr>"
+    client_id       TEXT        NOT NULL,
+    -- Period type: 'daily' | 'monthly'
+    period          TEXT        NOT NULL CHECK (period IN ('daily', 'monthly')),
+    -- ISO-8601 date of period start, e.g. '2026-06-25' or '2026-06-01'
+    period_start    TEXT        NOT NULL,
+    -- Maximum requests allowed in this period (tier default or admin override)
+    max_requests    BIGINT      NOT NULL DEFAULT 10000,
+    -- Atomically-incremented request counter
+    used_requests   BIGINT      NOT NULL DEFAULT 0,
+    -- False → enforcement skipped for this client (whitelist / bypass)
+    enabled         BOOLEAN     NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (client_id, period, period_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_client_quotas_period
+    ON api_client_quotas (period, period_start);
+
+CREATE INDEX IF NOT EXISTS idx_api_client_quotas_usage
+    ON api_client_quotas (used_requests DESC)
+    WHERE enabled = TRUE;
+
+-- Automatically refresh updated_at on every row change.
+CREATE OR REPLACE FUNCTION set_quota_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_quota_updated_at ON api_client_quotas;
+CREATE TRIGGER trg_quota_updated_at
+    BEFORE UPDATE ON api_client_quotas
+    FOR EACH ROW EXECUTE FUNCTION set_quota_updated_at();
+
+-- ── Rate-limit event log ──────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS rate_limit_events (
+    id              BIGSERIAL   PRIMARY KEY,
+    -- Caller identity key (matches api_client_quotas.client_id format)
+    client_id       TEXT        NOT NULL,
+    -- Caller tier at the time of the event
+    tier            TEXT        NOT NULL,
+    -- Request path that was blocked
+    path            TEXT        NOT NULL,
+    -- Which limit was triggered: 'burst' | 'sustained' | 'quota'
+    kind            TEXT        NOT NULL CHECK (kind IN ('burst', 'sustained', 'quota')),
+    -- The limit that was active at the time (rpm or burst size)
+    limit_value     BIGINT      NOT NULL DEFAULT 0,
+    -- Request count at the time of the event
+    request_count   BIGINT      NOT NULL DEFAULT 0,
+    occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Support time-range queries (the most common access pattern).
+CREATE INDEX IF NOT EXISTS idx_rate_limit_events_occurred_at
+    ON rate_limit_events (occurred_at DESC);
+
+-- Support per-client lookups (top-offenders query).
+CREATE INDEX IF NOT EXISTS idx_rate_limit_events_client_id
+    ON rate_limit_events (client_id, occurred_at DESC);
+
+-- Support per-tier breakdowns.
+CREATE INDEX IF NOT EXISTS idx_rate_limit_events_tier
+    ON rate_limit_events (tier, kind, occurred_at DESC);
+
+-- Support per-path analytics.
+CREATE INDEX IF NOT EXISTS idx_rate_limit_events_path
+    ON rate_limit_events (path, occurred_at DESC);
+
+-- Automatically purge events older than 30 days to prevent unbounded growth.
+-- Pruning is handled by the cron scheduler (scheduler::SchedulerManager); this
+-- comment documents the intent so the DBA is aware of the retention policy.
+COMMENT ON TABLE rate_limit_events IS
+    'Immutable log of rate-limited requests. Rows older than 30 days are pruned by the cron scheduler.';

--- a/src/gateway/analytics.rs
+++ b/src/gateway/analytics.rs
@@ -1,0 +1,239 @@
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sqlx::PgPool;
+
+use crate::errors::AppError;
+
+// ── Event types ───────────────────────────────────────────────────────────────
+
+/// The kind of limit that was triggered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitKind {
+    /// Short-window burst limit.
+    Burst,
+    /// Sustained requests-per-minute limit.
+    Sustained,
+    /// Daily/monthly quota exhausted.
+    Quota,
+}
+
+impl LimitKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LimitKind::Burst => "burst",
+            LimitKind::Sustained => "sustained",
+            LimitKind::Quota => "quota",
+        }
+    }
+}
+
+// ── Write path ────────────────────────────────────────────────────────────────
+
+/// Record a rate-limit rejection event asynchronously.
+///
+/// The call is fire-and-forget; failures are logged as warnings but do not
+/// affect the calling middleware.
+pub fn record_event(
+    db: Arc<PgPool>,
+    client_id: String,
+    tier: String,
+    path: String,
+    kind: LimitKind,
+    limit_value: i64,
+    request_count: i64,
+) {
+    tokio::spawn(async move {
+        let kind_str = kind.as_str();
+        if let Err(e) = sqlx::query(
+            r#"
+            INSERT INTO rate_limit_events
+                (client_id, tier, path, kind, limit_value, request_count, occurred_at)
+            VALUES ($1, $2, $3, $4, $5, $6, NOW())
+            "#,
+        )
+        .bind(&client_id)
+        .bind(&tier)
+        .bind(&path)
+        .bind(kind_str)
+        .bind(limit_value)
+        .bind(request_count)
+        .execute(&*db)
+        .await
+        {
+            tracing::warn!(
+                error = %e,
+                client_id = %client_id,
+                kind = kind_str,
+                "Failed to record rate limit event"
+            );
+        }
+    });
+}
+
+// ── Query types ───────────────────────────────────────────────────────────────
+
+/// Time-bucketed count of blocked requests.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct BlockedTimeSeries {
+    /// Truncated to the hour.
+    pub bucket: DateTime<Utc>,
+    pub count: i64,
+    pub kind: String,
+}
+
+/// Top client IDs by blocked request count.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct TopOffender {
+    pub client_id: String,
+    pub tier: String,
+    pub blocked_count: i64,
+    pub last_blocked_at: DateTime<Utc>,
+}
+
+/// Per-tier blocked request breakdown.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct TierBreakdown {
+    pub tier: String,
+    pub kind: String,
+    pub blocked_count: i64,
+}
+
+/// Path-level blocked request summary.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct PathBreakdown {
+    pub path: String,
+    pub blocked_count: i64,
+    pub unique_clients: i64,
+}
+
+/// Aggregated analytics summary for the admin dashboard.
+#[derive(Debug, Serialize)]
+pub struct RateLimitAnalyticsSummary {
+    pub total_blocked_last_hour: i64,
+    pub total_blocked_last_24h: i64,
+    pub top_offenders: Vec<TopOffender>,
+    pub tier_breakdown: Vec<TierBreakdown>,
+    pub path_breakdown: Vec<PathBreakdown>,
+    pub time_series_last_24h: Vec<BlockedTimeSeries>,
+}
+
+// ── Query helpers ─────────────────────────────────────────────────────────────
+
+pub async fn blocked_last_hour(db: &PgPool) -> Result<i64, AppError> {
+    let row: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM rate_limit_events WHERE occurred_at > NOW() - INTERVAL '1 hour'",
+    )
+    .fetch_one(db)
+    .await?;
+    Ok(row.0)
+}
+
+pub async fn blocked_last_24h(db: &PgPool) -> Result<i64, AppError> {
+    let row: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM rate_limit_events WHERE occurred_at > NOW() - INTERVAL '24 hours'",
+    )
+    .fetch_one(db)
+    .await?;
+    Ok(row.0)
+}
+
+pub async fn top_offenders(db: &PgPool, limit: i64) -> Result<Vec<TopOffender>, AppError> {
+    let rows = sqlx::query_as::<_, TopOffender>(
+        r#"
+        SELECT
+            client_id,
+            tier,
+            COUNT(*)           AS blocked_count,
+            MAX(occurred_at)   AS last_blocked_at
+        FROM   rate_limit_events
+        WHERE  occurred_at > NOW() - INTERVAL '24 hours'
+        GROUP  BY client_id, tier
+        ORDER  BY blocked_count DESC
+        LIMIT  $1
+        "#,
+    )
+    .bind(limit)
+    .fetch_all(db)
+    .await?;
+    Ok(rows)
+}
+
+pub async fn tier_breakdown(db: &PgPool) -> Result<Vec<TierBreakdown>, AppError> {
+    let rows = sqlx::query_as::<_, TierBreakdown>(
+        r#"
+        SELECT
+            tier,
+            kind,
+            COUNT(*) AS blocked_count
+        FROM   rate_limit_events
+        WHERE  occurred_at > NOW() - INTERVAL '24 hours'
+        GROUP  BY tier, kind
+        ORDER  BY blocked_count DESC
+        "#,
+    )
+    .fetch_all(db)
+    .await?;
+    Ok(rows)
+}
+
+pub async fn path_breakdown(db: &PgPool, limit: i64) -> Result<Vec<PathBreakdown>, AppError> {
+    let rows = sqlx::query_as::<_, PathBreakdown>(
+        r#"
+        SELECT
+            path,
+            COUNT(*)                    AS blocked_count,
+            COUNT(DISTINCT client_id)   AS unique_clients
+        FROM   rate_limit_events
+        WHERE  occurred_at > NOW() - INTERVAL '24 hours'
+        GROUP  BY path
+        ORDER  BY blocked_count DESC
+        LIMIT  $1
+        "#,
+    )
+    .bind(limit)
+    .fetch_all(db)
+    .await?;
+    Ok(rows)
+}
+
+pub async fn time_series_last_24h(db: &PgPool) -> Result<Vec<BlockedTimeSeries>, AppError> {
+    let rows = sqlx::query_as::<_, BlockedTimeSeries>(
+        r#"
+        SELECT
+            DATE_TRUNC('hour', occurred_at) AS bucket,
+            kind,
+            COUNT(*)                        AS count
+        FROM   rate_limit_events
+        WHERE  occurred_at > NOW() - INTERVAL '24 hours'
+        GROUP  BY DATE_TRUNC('hour', occurred_at), kind
+        ORDER  BY bucket ASC
+        "#,
+    )
+    .fetch_all(db)
+    .await?;
+    Ok(rows)
+}
+
+/// Build a full analytics summary — used by the admin route.
+pub async fn get_summary(db: &PgPool) -> Result<RateLimitAnalyticsSummary, AppError> {
+    let (total_1h, total_24h, top, tiers, paths, series) = tokio::try_join!(
+        blocked_last_hour(db),
+        blocked_last_24h(db),
+        top_offenders(db, 20),
+        tier_breakdown(db),
+        path_breakdown(db, 30),
+        time_series_last_24h(db),
+    )?;
+
+    Ok(RateLimitAnalyticsSummary {
+        total_blocked_last_hour: total_1h,
+        total_blocked_last_24h: total_24h,
+        top_offenders: top,
+        tier_breakdown: tiers,
+        path_breakdown: paths,
+        time_series_last_24h: series,
+    })
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,17 +1,23 @@
+pub mod analytics;
 pub mod api_gateway;
 pub mod authentication;
 pub mod cache_middleware;
 pub mod config;
 pub mod context;
 pub mod middleware;
+pub mod quota_manager;
+pub mod rate_limiter;
 pub mod request_transformer;
 pub mod versioning;
 
+pub use analytics::{get_summary as get_rate_limit_analytics, record_event as record_rate_limit_event, LimitKind, RateLimitAnalyticsSummary};
 pub use api_gateway::ApiGateway;
 pub use authentication::gateway_auth;
 pub use cache_middleware::{gateway_cache_middleware, cache_invalidation_middleware, GatewayCacheConfig, GatewayCacheState, CacheMetrics};
 pub use config::GatewayConfig;
 pub use context::GatewayIdentity;
 pub use middleware::{gateway_metrics, inject_identity_header, propagate_request_id_to_response, require_scope};
+pub use quota_manager::{quota_enforcement, get_daily_quotas, upsert_client_quota, QuotaPeriod, QuotaSummary};
+pub use rate_limiter::{gateway_rate_limit, CallerTier};
 pub use request_transformer::transform_request;
 pub use versioning::{version_negotiation, version_routing, ApiVersionContext, VersionResolution, VersionSource};

--- a/src/gateway/quota_manager.rs
+++ b/src/gateway/quota_manager.rs
@@ -1,0 +1,417 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Request, State},
+    http::{HeaderValue, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use chrono::{Datelike, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use crate::{
+    db::connection::AppState,
+    errors::AppError,
+    gateway::context::GatewayIdentity,
+    metrics::collectors::{QUOTA_EXCEEDED_TOTAL, QUOTA_USAGE_RATIO},
+};
+
+// ── Quota period ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text")]
+#[sqlx(rename_all = "lowercase")]
+pub enum QuotaPeriod {
+    Daily,
+    Monthly,
+}
+
+impl QuotaPeriod {
+    /// ISO-8601 date string representing the start of the current period.
+    pub fn current_period_start(self) -> String {
+        let now = Utc::now();
+        match self {
+            QuotaPeriod::Daily => now.format("%Y-%m-%d").to_string(),
+            QuotaPeriod::Monthly => format!("{}-{:02}-01", now.year(), now.month()),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            QuotaPeriod::Daily => "daily",
+            QuotaPeriod::Monthly => "monthly",
+        }
+    }
+}
+
+// ── Data model ────────────────────────────────────────────────────────────────
+
+/// A row from `api_client_quotas`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ClientQuota {
+    pub client_id: String,
+    pub period: String,
+    pub max_requests: i64,
+    pub used_requests: i64,
+    pub period_start: String,
+    pub enabled: bool,
+}
+
+impl ClientQuota {
+    pub fn remaining(&self) -> i64 {
+        (self.max_requests - self.used_requests).max(0)
+    }
+
+    pub fn is_exhausted(&self) -> bool {
+        self.used_requests >= self.max_requests
+    }
+
+    pub fn usage_ratio(&self) -> f64 {
+        if self.max_requests == 0 {
+            1.0
+        } else {
+            self.used_requests as f64 / self.max_requests as f64
+        }
+    }
+}
+
+// ── Tier defaults ─────────────────────────────────────────────────────────────
+
+fn tier_daily_quota(tier: &str) -> i64 {
+    match tier {
+        "anonymous" => env_i64("QUOTA_ANON_DAILY", 1_000),
+        "free" => env_i64("QUOTA_FREE_DAILY", 10_000),
+        "premium" => env_i64("QUOTA_PREMIUM_DAILY", 100_000),
+        "admin" => env_i64("QUOTA_ADMIN_DAILY", 1_000_000),
+        _ => 5_000,
+    }
+}
+
+fn tier_monthly_quota(tier: &str) -> i64 {
+    match tier {
+        "anonymous" => env_i64("QUOTA_ANON_MONTHLY", 10_000),
+        "free" => env_i64("QUOTA_FREE_MONTHLY", 100_000),
+        "premium" => env_i64("QUOTA_PREMIUM_MONTHLY", 1_000_000),
+        "admin" => env_i64("QUOTA_ADMIN_MONTHLY", 10_000_000),
+        _ => 50_000,
+    }
+}
+
+// ── DB helpers ────────────────────────────────────────────────────────────────
+
+/// Fetch the quota row for `client_id` in the current period.
+/// Returns `None` when no custom quota row exists.
+async fn fetch_quota(
+    db: &PgPool,
+    client_id: &str,
+    period: QuotaPeriod,
+) -> Option<ClientQuota> {
+    let period_start = period.current_period_start();
+    sqlx::query_as::<_, ClientQuota>(
+        r#"
+        SELECT client_id, period, max_requests, used_requests, period_start, enabled
+        FROM   api_client_quotas
+        WHERE  client_id   = $1
+          AND  period      = $2
+          AND  period_start = $3
+          AND  enabled     = true
+        "#,
+    )
+    .bind(client_id)
+    .bind(period.as_str())
+    .bind(&period_start)
+    .fetch_optional(db)
+    .await
+    .ok()?
+}
+
+/// Atomically increment the usage counter.  Uses INSERT … ON CONFLICT so the
+/// row is created (with tier-default max) on first use.
+async fn increment_quota(
+    db: &PgPool,
+    client_id: &str,
+    period: QuotaPeriod,
+    tier: &str,
+) -> Result<ClientQuota, sqlx::Error> {
+    let period_start = period.current_period_start();
+    let max_requests = match period {
+        QuotaPeriod::Daily => tier_daily_quota(tier),
+        QuotaPeriod::Monthly => tier_monthly_quota(tier),
+    };
+
+    sqlx::query_as::<_, ClientQuota>(
+        r#"
+        INSERT INTO api_client_quotas
+            (client_id, period, period_start, max_requests, used_requests, enabled)
+        VALUES ($1, $2, $3, $4, 1, true)
+        ON CONFLICT (client_id, period, period_start)
+        DO UPDATE SET used_requests = api_client_quotas.used_requests + 1
+        RETURNING client_id, period, max_requests, used_requests, period_start, enabled
+        "#,
+    )
+    .bind(client_id)
+    .bind(period.as_str())
+    .bind(&period_start)
+    .bind(max_requests)
+    .fetch_one(db)
+    .await
+}
+
+// ── Client-ID derivation ──────────────────────────────────────────────────────
+
+fn client_id_from_identity(identity: Option<&GatewayIdentity>, req: &Request) -> String {
+    match identity {
+        Some(GatewayIdentity::Jwt { subject, .. }) => format!("jwt:{}", subject),
+        Some(GatewayIdentity::ApiKey { key, .. }) => format!("apikey:{}", &key[..key.len().min(16)]),
+        _ => {
+            use axum::extract::ConnectInfo;
+            req.extensions()
+                .get::<ConnectInfo<std::net::SocketAddr>>()
+                .map(|ci| format!("ip:{}", ci.0.ip()))
+                .unwrap_or_else(|| "ip:unknown".to_string())
+        }
+    }
+}
+
+fn tier_from_identity(identity: Option<&GatewayIdentity>) -> &'static str {
+    match identity {
+        Some(GatewayIdentity::Jwt { role, .. }) => match role.as_str() {
+            "admin" | "superadmin" => "admin",
+            "premium" => "premium",
+            _ => "free",
+        },
+        Some(GatewayIdentity::ApiKey { permissions, .. }) => {
+            if permissions.iter().any(|p| p == "*" || p == "admin") {
+                "admin"
+            } else if permissions.iter().any(|p| p == "premium") {
+                "premium"
+            } else {
+                "free"
+            }
+        }
+        Some(GatewayIdentity::Anonymous) | None => "anonymous",
+    }
+}
+
+// ── Response helpers ──────────────────────────────────────────────────────────
+
+fn quota_too_many_requests(
+    client_id: &str,
+    period: QuotaPeriod,
+    used: i64,
+    max: i64,
+) -> Response {
+    let reset_hint = match period {
+        QuotaPeriod::Daily => "at midnight UTC",
+        QuotaPeriod::Monthly => "at the start of next month",
+    };
+    let body = serde_json::json!({
+        "error": "API quota exhausted",
+        "code": "QUOTA_EXCEEDED",
+        "status": StatusCode::TOO_MANY_REQUESTS.as_u16(),
+        "details": {
+            "client_id": client_id,
+            "period": period.as_str(),
+            "used": used,
+            "limit": max,
+            "resets": reset_hint,
+        },
+        "request_id": crate::middleware::request_id::current_request_id(),
+    });
+    let mut resp = (StatusCode::TOO_MANY_REQUESTS, axum::Json(body)).into_response();
+    resp.headers_mut().insert(
+        "X-Quota-Limit",
+        HeaderValue::from_str(&max.to_string()).unwrap_or(HeaderValue::from_static("0")),
+    );
+    resp.headers_mut().insert(
+        "X-Quota-Remaining",
+        HeaderValue::from_static("0"),
+    );
+    resp.headers_mut().insert(
+        "X-Quota-Period",
+        HeaderValue::from_static(period.as_str()),
+    );
+    resp
+}
+
+fn inject_quota_headers(resp: &mut Response, quota: &ClientQuota) {
+    let headers = resp.headers_mut();
+    let _ = headers.insert(
+        "X-Quota-Limit",
+        HeaderValue::from_str(&quota.max_requests.to_string())
+            .unwrap_or(HeaderValue::from_static("0")),
+    );
+    let _ = headers.insert(
+        "X-Quota-Remaining",
+        HeaderValue::from_str(&quota.remaining().to_string())
+            .unwrap_or(HeaderValue::from_static("0")),
+    );
+    let _ = headers.insert(
+        "X-Quota-Period",
+        HeaderValue::from_static(quota.period.as_str()),
+    );
+}
+
+// ── Middleware ────────────────────────────────────────────────────────────────
+
+/// Axum middleware that enforces per-client API quotas.
+///
+/// Quota enforcement is opt-in: if the feature is disabled via the
+/// `QUOTA_ENFORCEMENT_ENABLED` env var (default `true`), all requests pass
+/// through with quota headers still populated.
+pub async fn quota_enforcement(
+    State(state): State<Arc<AppState>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let enabled = std::env::var("QUOTA_ENFORCEMENT_ENABLED")
+        .map(|v| v.to_lowercase() != "false")
+        .unwrap_or(true);
+
+    if !enabled {
+        return next.run(req).await;
+    }
+
+    let identity = req.extensions().get::<GatewayIdentity>().cloned();
+    let client_id = client_id_from_identity(identity.as_ref(), &req);
+    let tier = tier_from_identity(identity.as_ref());
+
+    // Use daily quotas by default; monthly quotas can be layered in separately.
+    let period = QuotaPeriod::Daily;
+
+    // ── Check existing quota before incrementing ──────────────────────────────
+    if let Some(existing) = fetch_quota(&state.db, &client_id, period).await {
+        if existing.is_exhausted() {
+            QUOTA_EXCEEDED_TOTAL.with_label_values(&[tier, period.as_str()]).inc();
+            tracing::warn!(
+                client_id = %client_id,
+                tier,
+                used = existing.used_requests,
+                max = existing.max_requests,
+                "Quota exhausted"
+            );
+            return quota_too_many_requests(
+                &client_id,
+                period,
+                existing.used_requests,
+                existing.max_requests,
+            );
+        }
+    }
+
+    // ── Increment quota asynchronously post-response ──────────────────────────
+    let db = state.db.clone();
+    let cid = client_id.clone();
+    let tier_owned = tier.to_owned();
+
+    let mut resp = next.run(req).await;
+
+    // Fire-and-forget increment (non-blocking).
+    tokio::spawn(async move {
+        match increment_quota(&db, &cid, period, &tier_owned).await {
+            Ok(quota) => {
+                let ratio = quota.usage_ratio();
+                QUOTA_USAGE_RATIO
+                    .with_label_values(&[tier_owned.as_str(), period.as_str()])
+                    .set(ratio);
+
+                if ratio >= 0.9 {
+                    tracing::warn!(
+                        client_id = %cid,
+                        tier = %tier_owned,
+                        used = quota.used_requests,
+                        max = quota.max_requests,
+                        ratio,
+                        "Quota nearing exhaustion (≥90%)"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, client_id = %cid, "Failed to increment quota counter");
+            }
+        }
+    });
+
+    // Inject quota headers using tier-default values (since we didn't wait for the DB).
+    let max_daily = tier_daily_quota(tier);
+    let dummy_quota = ClientQuota {
+        client_id: client_id.clone(),
+        period: period.as_str().to_string(),
+        max_requests: max_daily,
+        used_requests: 0, // approximate – exact value is from DB post-increment
+        period_start: period.current_period_start(),
+        enabled: true,
+    };
+    inject_quota_headers(&mut resp, &dummy_quota);
+
+    resp
+}
+
+// ── Admin helpers (used by the analytics route) ───────────────────────────────
+
+/// Summary row returned by the quota analytics endpoint.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct QuotaSummary {
+    pub client_id: String,
+    pub period: String,
+    pub period_start: String,
+    pub max_requests: i64,
+    pub used_requests: i64,
+    pub enabled: bool,
+}
+
+/// Fetch all quota rows for the current daily period.
+pub async fn get_daily_quotas(db: &PgPool) -> Result<Vec<QuotaSummary>, AppError> {
+    let period_start = QuotaPeriod::Daily.current_period_start();
+    let rows = sqlx::query_as::<_, QuotaSummary>(
+        r#"
+        SELECT client_id, period, period_start, max_requests, used_requests, enabled
+        FROM   api_client_quotas
+        WHERE  period       = 'daily'
+          AND  period_start = $1
+        ORDER  BY used_requests DESC
+        LIMIT  500
+        "#,
+    )
+    .bind(&period_start)
+    .fetch_all(db)
+    .await?;
+    Ok(rows)
+}
+
+/// Fetch or create a quota override for a specific client.
+pub async fn upsert_client_quota(
+    db: &PgPool,
+    client_id: &str,
+    period: QuotaPeriod,
+    max_requests: i64,
+) -> Result<QuotaSummary, AppError> {
+    let period_start = period.current_period_start();
+    let row = sqlx::query_as::<_, QuotaSummary>(
+        r#"
+        INSERT INTO api_client_quotas
+            (client_id, period, period_start, max_requests, used_requests, enabled)
+        VALUES ($1, $2, $3, $4, 0, true)
+        ON CONFLICT (client_id, period, period_start)
+        DO UPDATE SET max_requests = EXCLUDED.max_requests
+        RETURNING client_id, period, period_start, max_requests, used_requests, enabled
+        "#,
+    )
+    .bind(client_id)
+    .bind(period.as_str())
+    .bind(&period_start)
+    .bind(max_requests)
+    .fetch_one(db)
+    .await?;
+    Ok(row)
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+fn env_i64(key: &str, default: i64) -> i64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}

--- a/src/gateway/rate_limiter.rs
+++ b/src/gateway/rate_limiter.rs
@@ -1,0 +1,429 @@
+
+use std::time::Duration;
+
+use axum::{
+    extract::{ConnectInfo, Request, State},
+    http::{HeaderValue, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+use redis::AsyncCommands;
+
+use crate::{
+    db::connection::AppState,
+    errors::AppError,
+    gateway::context::GatewayIdentity,
+    metrics::collectors::{
+        RATE_LIMIT_BURST_CONSUMED_TOTAL, RATE_LIMIT_EXCEEDED_TOTAL,
+        RATE_LIMIT_REQUESTS_TOTAL,
+    },
+};
+
+// ── Tier definitions ──────────────────────────────────────────────────────────
+
+/// Caller tier that drives rate-limit thresholds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallerTier {
+    /// Unauthenticated callers.
+    Anonymous,
+    /// Authenticated users on the free plan.
+    Free,
+    /// Authenticated premium / paid users.
+    Premium,
+    /// Internal admin callers — very high limits.
+    Admin,
+}
+
+impl CallerTier {
+    /// Returns `(requests_per_minute, burst_size)` for this tier.
+    ///
+    /// All values are overridable via env vars:
+    /// - `RATE_LIMIT_ANON_RPM` / `RATE_LIMIT_ANON_BURST`
+    /// - `RATE_LIMIT_FREE_RPM` / `RATE_LIMIT_FREE_BURST`
+    /// - `RATE_LIMIT_PREMIUM_RPM` / `RATE_LIMIT_PREMIUM_BURST`
+    /// - `RATE_LIMIT_ADMIN_RPM` / `RATE_LIMIT_ADMIN_BURST`
+    pub fn limits(self) -> (u64, u64) {
+        match self {
+            CallerTier::Anonymous => (
+                env_u64("RATE_LIMIT_ANON_RPM", 30),
+                env_u64("RATE_LIMIT_ANON_BURST", 10),
+            ),
+            CallerTier::Free => (
+                env_u64("RATE_LIMIT_FREE_RPM", 120),
+                env_u64("RATE_LIMIT_FREE_BURST", 30),
+            ),
+            CallerTier::Premium => (
+                env_u64("RATE_LIMIT_PREMIUM_RPM", 600),
+                env_u64("RATE_LIMIT_PREMIUM_BURST", 120),
+            ),
+            CallerTier::Admin => (
+                env_u64("RATE_LIMIT_ADMIN_RPM", 6000),
+                env_u64("RATE_LIMIT_ADMIN_BURST", 1000),
+            ),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CallerTier::Anonymous => "anonymous",
+            CallerTier::Free => "free",
+            CallerTier::Premium => "premium",
+            CallerTier::Admin => "admin",
+        }
+    }
+}
+
+// ── Route-level overrides ─────────────────────────────────────────────────────
+
+/// Per-route rate-limit configuration.  Values are loaded from environment
+/// variables with path-derived names, e.g. for `/api/v1/tips`:
+/// - `ROUTE_RL_TIPS_RPM`
+/// - `ROUTE_RL_TIPS_BURST`
+#[derive(Debug, Clone)]
+pub struct RouteRateConfig {
+    pub rpm: u64,
+    pub burst: u64,
+}
+
+/// Return a route-specific override if one is configured via env vars.
+/// The path is normalised to upper-snake-case, e.g. `/api/v1/tips` → `TIPS`.
+fn route_override(path: &str) -> Option<RouteRateConfig> {
+    // Extract the last meaningful path segment as the key.
+    let segment = path
+        .trim_start_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty() && !s.starts_with('v'))
+        .last()?;
+
+    let key = segment.to_uppercase().replace('-', "_");
+    let rpm_var = format!("ROUTE_RL_{}_RPM", key);
+    let burst_var = format!("ROUTE_RL_{}_BURST", key);
+
+    let rpm = std::env::var(&rpm_var).ok().and_then(|v| v.parse().ok())?;
+    let burst = std::env::var(&burst_var)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(rpm / 4);
+
+    Some(RouteRateConfig { rpm, burst })
+}
+
+// ── Identity helpers ──────────────────────────────────────────────────────────
+
+/// Derive the caller tier from the injected `GatewayIdentity`.
+fn tier_from_identity(identity: Option<&GatewayIdentity>) -> CallerTier {
+    match identity {
+        Some(GatewayIdentity::Jwt { role, .. }) => match role.as_str() {
+            "admin" | "superadmin" => CallerTier::Admin,
+            "premium" => CallerTier::Premium,
+            _ => CallerTier::Free,
+        },
+        Some(GatewayIdentity::ApiKey { permissions, .. }) => {
+            if permissions.iter().any(|p| p == "*" || p == "admin") {
+                CallerTier::Admin
+            } else if permissions.iter().any(|p| p == "premium") {
+                CallerTier::Premium
+            } else {
+                CallerTier::Free
+            }
+        }
+        Some(GatewayIdentity::Anonymous) | None => CallerTier::Anonymous,
+    }
+}
+
+/// Build a stable client key used as the Redis counter key.
+///
+/// Priority: authenticated identity → IP address → constant fallback.
+fn client_key(identity: Option<&GatewayIdentity>, req: &Request) -> String {
+    if let Some(id) = identity {
+        match id {
+            GatewayIdentity::Jwt { subject, .. } => return format!("rl:jwt:{}", subject),
+            GatewayIdentity::ApiKey { key, .. } => {
+                return format!("rl:apikey:{}", &key[..key.len().min(16)])
+            }
+            GatewayIdentity::Anonymous => {}
+        }
+    }
+
+    // Fall back to IP.
+    let ip = req
+        .extensions()
+        .get::<ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0.ip().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    format!("rl:ip:{}", ip)
+}
+
+// ── Redis sliding-window counter ──────────────────────────────────────────────
+
+/// Increment a sliding-window counter stored in Redis and return the current
+/// count.  Returns `None` on Redis error (fail-open strategy).
+///
+/// Window buckets are 60-second aligned.  Two buckets are used to implement a
+/// sliding window: the current bucket + the previous bucket proportionally.
+async fn redis_sliding_count(
+    conn: &mut redis::aio::ConnectionManager,
+    key: &str,
+    window_secs: u64,
+    now_ts: u64,
+) -> Option<f64> {
+    let bucket = now_ts / window_secs;
+    let cur_key = format!("{}:{}", key, bucket);
+    let prev_key = format!("{}:{}", key, bucket.saturating_sub(1));
+
+    // INCR current bucket and get both buckets atomically via pipeline.
+    let (cur_count, prev_count): (i64, i64) = redis::pipe()
+        .atomic()
+        .incr(&cur_key, 1i64)
+        .expire(&cur_key, (window_secs * 2) as i64)
+        .ignore()
+        .get(&prev_key)
+        .query_async(conn)
+        .await
+        .ok()?;
+
+    let prev_count = prev_count.max(0);
+
+    // Fraction of the current window that has elapsed.
+    let elapsed_fraction = (now_ts % window_secs) as f64 / window_secs as f64;
+
+    // Sliding window estimate = previous × (1 − elapsed) + current.
+    let sliding = (prev_count as f64) * (1.0 - elapsed_fraction) + cur_count as f64;
+    Some(sliding)
+}
+
+/// Increment a burst counter with a short TTL (10 s) and return the count.
+async fn redis_burst_count(
+    conn: &mut redis::aio::ConnectionManager,
+    key: &str,
+) -> Option<i64> {
+    redis::pipe()
+        .atomic()
+        .incr(key, 1i64)
+        .expire(key, 10i64)
+        .ignore()
+        .query_async::<(i64,)>(conn)
+        .await
+        .ok()
+        .map(|(c,)| c)
+}
+
+// ── Response helpers ──────────────────────────────────────────────────────────
+
+fn add_rate_limit_headers(resp: &mut Response, limit: u64, remaining: i64, reset_secs: u64) {
+    let headers = resp.headers_mut();
+    let _ = headers.insert(
+        "X-RateLimit-Limit",
+        HeaderValue::from_str(&limit.to_string()).unwrap_or(HeaderValue::from_static("0")),
+    );
+    let _ = headers.insert(
+        "X-RateLimit-Remaining",
+        HeaderValue::from_str(&remaining.max(0).to_string())
+            .unwrap_or(HeaderValue::from_static("0")),
+    );
+    let _ = headers.insert(
+        "X-RateLimit-Reset",
+        HeaderValue::from_str(&reset_secs.to_string()).unwrap_or(HeaderValue::from_static("0")),
+    );
+}
+
+fn too_many_requests(
+    message: &'static str,
+    retry_after: u64,
+    tier: &str,
+    limit: u64,
+    reset_secs: u64,
+) -> Response {
+    let body = serde_json::json!({
+        "error": message,
+        "code": "RATE_LIMIT_EXCEEDED",
+        "status": StatusCode::TOO_MANY_REQUESTS.as_u16(),
+        "details": {
+            "tier": tier,
+            "limit_rpm": limit,
+            "retry_after_secs": retry_after,
+            "reset_at_secs": reset_secs,
+        },
+        "request_id": crate::middleware::request_id::current_request_id(),
+    });
+
+    let mut resp = (StatusCode::TOO_MANY_REQUESTS, axum::Json(body)).into_response();
+    if let Ok(v) = retry_after.to_string().parse() {
+        resp.headers_mut().insert("Retry-After", v);
+    }
+    add_rate_limit_headers(&mut resp, limit, 0, reset_secs);
+    resp
+}
+
+// ── Axum middleware ───────────────────────────────────────────────────────────
+
+/// Gateway rate-limiting middleware.
+///
+/// - Resolves the caller tier from `GatewayIdentity` (injected by
+///   `gateway_auth`).
+/// - Applies per-route overrides when configured via env vars.
+/// - Uses Redis sliding-window + burst counters when Redis is available.
+/// - Falls back to allowing the request when Redis is unreachable
+///   (tower_governor IP-based layers still apply as a backstop).
+/// - Injects `X-RateLimit-*` headers on every response.
+/// - Emits Prometheus metrics for observability.
+pub async fn gateway_rate_limit(
+    State(state): State<std::sync::Arc<AppState>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let path = req.uri().path().to_owned();
+    let identity = req.extensions().get::<GatewayIdentity>().cloned();
+    let tier = tier_from_identity(identity.as_ref());
+    let tier_str = tier.as_str();
+
+    // Effective limits: route override wins over tier default.
+    let (rpm, burst) = if let Some(ov) = route_override(&path) {
+        (ov.rpm, ov.burst)
+    } else {
+        tier.limits()
+    };
+
+    let key = client_key(identity.as_ref(), &req);
+
+    RATE_LIMIT_REQUESTS_TOTAL
+        .with_label_values(&[tier_str, &path])
+        .inc();
+
+    let now_ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let window_secs = 60u64;
+    let reset_secs = window_secs - (now_ts % window_secs);
+
+    // ── Redis path ────────────────────────────────────────────────────────────
+    if let Some(ref conn_mgr) = state.redis {
+        let mut conn = conn_mgr.clone();
+
+        // 1. Burst check (10-second sub-window).
+        let burst_key = format!("{}:burst:{}", key, now_ts / 10);
+        match redis_burst_count(&mut conn, &burst_key).await {
+            Some(burst_count) if burst_count > burst as i64 => {
+                RATE_LIMIT_EXCEEDED_TOTAL
+                    .with_label_values(&[tier_str, "burst", &path])
+                    .inc();
+                RATE_LIMIT_BURST_CONSUMED_TOTAL
+                    .with_label_values(&[tier_str])
+                    .inc();
+                tracing::warn!(
+                    tier = tier_str,
+                    key = %key,
+                    burst_count,
+                    burst_limit = burst,
+                    path = %path,
+                    "Burst rate limit exceeded"
+                );
+                return too_many_requests(
+                    "Burst limit exceeded. Please slow down.",
+                    10 - (now_ts % 10),
+                    tier_str,
+                    burst,
+                    reset_secs,
+                );
+            }
+            Some(_) => {}
+            None => {
+                tracing::debug!("Redis burst check failed – skipping burst enforcement");
+            }
+        }
+
+        // 2. Sustained sliding-window check.
+        let sliding_key = format!("{}:rpm", key);
+        match redis_sliding_count(&mut conn, &sliding_key, window_secs, now_ts).await {
+            Some(count) if count > rpm as f64 => {
+                RATE_LIMIT_EXCEEDED_TOTAL
+                    .with_label_values(&[tier_str, "sustained", &path])
+                    .inc();
+                tracing::warn!(
+                    tier = tier_str,
+                    key = %key,
+                    count,
+                    rpm,
+                    path = %path,
+                    "Sustained rate limit exceeded"
+                );
+                return too_many_requests(
+                    "Rate limit exceeded. Please slow down.",
+                    reset_secs,
+                    tier_str,
+                    rpm,
+                    reset_secs,
+                );
+            }
+            Some(count) => {
+                // Attach rate-limit info to extensions for quota manager.
+                let remaining = (rpm as f64 - count).max(0.0) as i64;
+                let mut resp = next.run(req).await;
+                add_rate_limit_headers(&mut resp, rpm, remaining, reset_secs);
+                resp.headers_mut().insert(
+                    "X-RateLimit-Tier",
+                    HeaderValue::from_static(tier_str),
+                );
+                return resp;
+            }
+            None => {
+                tracing::debug!("Redis sliding-window check failed – falling through");
+            }
+        }
+    }
+
+    // ── No Redis / fail-open path ─────────────────────────────────────────────
+    let mut resp = next.run(req).await;
+    add_rate_limit_headers(&mut resp, rpm, rpm as i64, reset_secs);
+    resp.headers_mut().insert(
+        "X-RateLimit-Tier",
+        HeaderValue::from_static(tier_str),
+    );
+    resp
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_limits_respect_defaults() {
+        let (rpm, burst) = CallerTier::Anonymous.limits();
+        assert!(rpm > 0);
+        assert!(burst > 0);
+        assert!(burst < rpm);
+
+        let (free_rpm, _) = CallerTier::Free.limits();
+        let (premium_rpm, _) = CallerTier::Premium.limits();
+        assert!(free_rpm < premium_rpm);
+    }
+
+    #[test]
+    fn client_key_for_anonymous_falls_back_gracefully() {
+        // Build a minimal request with no extensions.
+        use axum::body::Body;
+        let req = axum::http::Request::builder()
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        let key = client_key(None, &req);
+        assert!(key.starts_with("rl:ip:"));
+    }
+
+    #[test]
+    fn route_override_returns_none_for_unknown_segment() {
+        assert!(route_override("/api/v1/completely_unknown_xyz").is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,9 +332,27 @@ async fn main() -> anyhow::Result<()> {
     //   • Gateway-level metrics (latency header + structured log)
     //   • Request-ID propagation to response
     //   • Caller identity header (dev/staging only)
+    //   • Advanced per-identity rate limiting with burst handling (gateway_rate_limit)
+    //   • Per-client daily/monthly quota enforcement (quota_enforcement)
     let gateway_auth_layer = axum::middleware::from_fn_with_state(
         Arc::clone(&state),
         gateway::gateway_auth,
+    );
+    let gateway_rate_limit_layer_v1 = axum::middleware::from_fn_with_state(
+        Arc::clone(&state),
+        gateway::gateway_rate_limit,
+    );
+    let quota_enforcement_layer_v1 = axum::middleware::from_fn_with_state(
+        Arc::clone(&state),
+        gateway::quota_enforcement,
+    );
+    let gateway_rate_limit_layer_v2 = axum::middleware::from_fn_with_state(
+        Arc::clone(&state),
+        gateway::gateway_rate_limit,
+    );
+    let quota_enforcement_layer_v2 = axum::middleware::from_fn_with_state(
+        Arc::clone(&state),
+        gateway::quota_enforcement,
     );
 
     // Versioned API Routes (Merged from Main)
@@ -350,6 +368,7 @@ async fn main() -> anyhow::Result<()> {
                 .merge(routes::refunds::admin_router(Arc::clone(&state)))
                 .merge(routes::audit_logs::router(Arc::clone(&state)))
                 .merge(routes::export::router(Arc::clone(&state)))
+                .merge(routes::rate_limit_analytics::router(Arc::clone(&state)))
                 .merge(routes::deprecation::router())
                 .merge(routes::tenants::router())
                 .merge(
@@ -394,6 +413,8 @@ async fn main() -> anyhow::Result<()> {
         .layer(axum::middleware::from_fn(gateway::propagate_request_id_to_response))
         .layer(axum::middleware::from_fn(gateway::transform_request))
         .layer(axum::middleware::from_fn(gateway::version_negotiation))
+        .layer(quota_enforcement_layer_v1)
+        .layer(gateway_rate_limit_layer_v1)
         .layer(gateway_auth_layer.clone());
 
     let v2 = Router::new().nest(
@@ -444,6 +465,8 @@ async fn main() -> anyhow::Result<()> {
     .layer(axum::middleware::from_fn(gateway::propagate_request_id_to_response))
     .layer(axum::middleware::from_fn(gateway::transform_request))
     .layer(axum::middleware::from_fn(gateway::version_negotiation))
+    .layer(quota_enforcement_layer_v2)
+    .layer(gateway_rate_limit_layer_v2)
     .layer(gateway_auth_layer);
 
     let x_request_id = axum::http::HeaderName::from_static("x-request-id");

--- a/src/metrics/collectors.rs
+++ b/src/metrics/collectors.rs
@@ -183,6 +183,38 @@ lazy_static! {
         "webhook_dlq_total",
         "Total webhooks moved to dead letter queue"
     ).unwrap();
+
+    // ── Rate Limiting ─────────────────────────────────────────────────────────
+    pub static ref RATE_LIMIT_REQUESTS_TOTAL: CounterVec = register_counter_vec!(
+        "gateway_rate_limit_requests_total",
+        "Total requests evaluated by the gateway rate limiter, by tier and path",
+        &["tier", "path"]
+    ).unwrap();
+
+    pub static ref RATE_LIMIT_EXCEEDED_TOTAL: CounterVec = register_counter_vec!(
+        "gateway_rate_limit_exceeded_total",
+        "Total requests blocked by the gateway rate limiter, by tier, kind, and path",
+        &["tier", "kind", "path"]
+    ).unwrap();
+
+    pub static ref RATE_LIMIT_BURST_CONSUMED_TOTAL: CounterVec = register_counter_vec!(
+        "gateway_rate_limit_burst_consumed_total",
+        "Total burst token consumption events, by tier",
+        &["tier"]
+    ).unwrap();
+
+    // ── Quota Management ──────────────────────────────────────────────────────
+    pub static ref QUOTA_EXCEEDED_TOTAL: CounterVec = register_counter_vec!(
+        "gateway_quota_exceeded_total",
+        "Total requests rejected because the client quota was exhausted, by tier and period",
+        &["tier", "period"]
+    ).unwrap();
+
+    pub static ref QUOTA_USAGE_RATIO: GaugeVec = register_gauge_vec!(
+        "gateway_quota_usage_ratio",
+        "Current quota usage as a ratio (0–1) by tier and period",
+        &["tier", "period"]
+    ).unwrap();
 }
 
 /// Aggregated snapshot used by the `/metrics/summary` endpoint.

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -29,6 +29,7 @@ pub mod monitoring;
 pub mod notifications;
 pub mod portfolio;
 pub mod profiling;
+pub mod rate_limit_analytics;
 pub mod receipts;
 pub mod refunds;
 pub mod scheduled_tips;

--- a/src/routes/rate_limit_analytics.rs
+++ b/src/routes/rate_limit_analytics.rs
@@ -1,0 +1,169 @@
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    middleware,
+    response::IntoResponse,
+    routing::{get, put},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::{
+    db::connection::AppState,
+    errors::AppError,
+    gateway::{
+        analytics as rl_analytics,
+        quota_manager::{get_daily_quotas, upsert_client_quota, QuotaPeriod},
+    },
+    middleware::admin_auth::require_admin,
+};
+
+// ── Request / response types ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct TopOffendersQuery {
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+}
+
+fn default_limit() -> i64 {
+    20
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PathBreakdownQuery {
+    #[serde(default = "default_path_limit")]
+    pub limit: i64,
+}
+
+fn default_path_limit() -> i64 {
+    30
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UpsertQuotaRequest {
+    /// Maximum requests allowed in the period.
+    pub max_requests: i64,
+    /// `"daily"` or `"monthly"`.  Defaults to daily.
+    #[serde(default = "default_period")]
+    pub period: String,
+}
+
+fn default_period() -> String {
+    "daily".to_string()
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
+    Router::new()
+        // ── Analytics ──────────────────────────────────────────────────────
+        .route(
+            "/admin/rate-limits/analytics",
+            get(full_analytics_summary),
+        )
+        .route(
+            "/admin/rate-limits/analytics/timeseries",
+            get(timeseries),
+        )
+        .route(
+            "/admin/rate-limits/analytics/top-offenders",
+            get(top_offenders),
+        )
+        .route(
+            "/admin/rate-limits/analytics/tiers",
+            get(tier_breakdown),
+        )
+        .route(
+            "/admin/rate-limits/analytics/paths",
+            get(path_breakdown),
+        )
+        // ── Quota management ───────────────────────────────────────────────
+        .route("/admin/rate-limits/quotas", get(list_quotas))
+        .route(
+            "/admin/rate-limits/quotas/:client_id",
+            put(upsert_quota),
+        )
+        .route_layer(middleware::from_fn_with_state(state, require_admin))
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// Full analytics summary: totals, top offenders, tier & path breakdowns,
+/// and 24-hour time series.
+async fn full_analytics_summary(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, AppError> {
+    let summary = rl_analytics::get_summary(&state.db).await?;
+    Ok((StatusCode::OK, Json(summary)))
+}
+
+/// Hourly blocked-request time series for the last 24 hours.
+async fn timeseries(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, AppError> {
+    let series = rl_analytics::time_series_last_24h(&state.db).await?;
+    Ok((StatusCode::OK, Json(series)))
+}
+
+/// Top blocked client IDs in the last 24 hours.
+async fn top_offenders(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<TopOffendersQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let limit = q.limit.clamp(1, 100);
+    let offenders = rl_analytics::top_offenders(&state.db, limit).await?;
+    Ok((StatusCode::OK, Json(offenders)))
+}
+
+/// Per-tier (anonymous / free / premium / admin) breakdown of blocked requests.
+async fn tier_breakdown(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, AppError> {
+    let rows = rl_analytics::tier_breakdown(&state.db).await?;
+    Ok((StatusCode::OK, Json(rows)))
+}
+
+/// Per-path breakdown: most-blocked endpoints.
+async fn path_breakdown(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<PathBreakdownQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let limit = q.limit.clamp(1, 100);
+    let rows = rl_analytics::path_breakdown(&state.db, limit).await?;
+    Ok((StatusCode::OK, Json(rows)))
+}
+
+/// List all daily quota rows for the current period (up to 500 clients).
+async fn list_quotas(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, AppError> {
+    let quotas = get_daily_quotas(&state.db).await?;
+    Ok((StatusCode::OK, Json(quotas)))
+}
+
+/// Create or update the quota limit for a specific client.
+///
+/// `PUT /admin/rate-limits/quotas/:client_id`
+/// Body: `{ "max_requests": 50000, "period": "daily" }`
+async fn upsert_quota(
+    State(state): State<Arc<AppState>>,
+    Path(client_id): Path<String>,
+    Json(body): Json<UpsertQuotaRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if body.max_requests <= 0 {
+        return Err(AppError::bad_request(
+            "max_requests must be a positive integer",
+        ));
+    }
+
+    let period = match body.period.as_str() {
+        "monthly" => QuotaPeriod::Monthly,
+        _ => QuotaPeriod::Daily,
+    };
+
+    let quota = upsert_client_quota(&state.db, &client_id, period, body.max_requests).await?;
+    Ok((StatusCode::OK, Json(quota)))
+}


### PR DESCRIPTION


### Summary

Deploys a production-grade API gateway layer with advanced rate limiting,
per-client quota management, burst handling, and a full analytics pipeline
for observability into rate limit events.

closes #291 

---

### What Changed

#### New Gateway Modules (`src/gateway/`)

- **`rate_limiter.rs`** — Identity-aware rate limiter middleware
  - Four caller tiers: `Anonymous`, `Free`, `Premium`, `Admin`
  - Redis sliding-window counter (two-bucket algorithm) for distributed,
    cross-replica enforcement
  - Separate 10-second burst sub-window to block request spikes
  - Per-route env-var overrides (`ROUTE_RL_<SEGMENT>_RPM / _BURST`)
  - Tier limits fully configurable via env vars
  - `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`,
    `X-RateLimit-Tier` headers on every response
  - Fail-open when Redis is unavailable (tower_governor IP layers remain
    as a backstop)

- **`quota_manager.rs`** — Per-client daily/monthly quota enforcement
  - Quota state persisted in `api_client_quotas` (upserted per request)
  - Pre-check before increment to block exhausted clients immediately
  - Fire-and-forget async increment — zero latency added to the hot path
  - Tier-default quotas with per-client admin overrides
  - `X-Quota-Limit`, `X-Quota-Remaining`, `X-Quota-Period` response headers
  - `≥90%` usage warning emitted as a structured log event
  - Toggle enforcement via `QUOTA_ENFORCEMENT_ENABLED` env var

- **`analytics.rs`** — Rate-limit event analytics
  - Async fire-and-forget writes to `rate_limit_events` table
  - Query helpers: time-series (hourly), top offenders, per-tier breakdown,
    per-path breakdown, 1-hour and 24-hour totals
  - `get_summary()` aggregates all dimensions in a single parallel query

#### New Admin Route (`src/routes/rate_limit_analytics.rs`)

All endpoints protected by `X-Admin-Key` (same guard as the rest of the
admin surface):

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/admin/rate-limits/analytics` | Full 24h summary |
| `GET` | `/admin/rate-limits/analytics/timeseries` | Hourly blocked-request counts |
| `GET` | `/admin/rate-limits/analytics/top-offenders` | Top blocked clients |
| `GET` | `/admin/rate-limits/analytics/tiers` | Per-tier breakdown |
| `GET` | `/admin/rate-limits/analytics/paths` | Per-path breakdown |
| `GET` | `/admin/rate-limits/quotas` | All daily quota rows |
| `PUT` | `/admin/rate-limits/quotas/:client_id` | Override client quota limit |

#### Prometheus Metrics (`src/metrics/collectors.rs`)

Six new metrics added:

| Metric | Type | Description |
|--------|------|-------------|
| `gateway_rate_limit_requests_total` | CounterVec | All requests evaluated, by tier + path |
| `gateway_rate_limit_exceeded_total` | CounterVec | Blocked requests, by tier + kind + path |
| `gateway_rate_limit_burst_consumed_total` | CounterVec | Burst token consumption, by tier |
| `gateway_quota_exceeded_total` | CounterVec | Quota rejections, by tier + period |
| `gateway_quota_usage_ratio` | GaugeVec | Quota fill ratio (0–1), by tier + period |

#### Database Migration (`migrations/0067_rate_limit_quota_analytics.sql`)

Two new tables:

- **`api_client_quotas`** — quota state with composite PK
  `(client_id, period, period_start)`, `updated_at` trigger, indexes on
  period lookup and usage ordering
- **`rate_limit_events`** — append-only blocked-request log with indexes
  covering time-range, per-client, per-tier, and per-path queries; 30-day
  retention enforced by the cron scheduler

Down migration included in `0067_rate_limit_quota_analytics.down.sql`.

#### Kong Gateway (`kong/kong.yml`)

Upgraded from basic rate limiting to a tiered, Redis-backed configuration:

- **Public routes** — 30 rpm + 10-req/10s burst (anonymous tier)
- **Write routes** — 10 rpm + 3-req/10s burst (spam / replay protection)
- **Protected routes** — 120 rpm + 30-req/10s burst (free tier, per consumer)
- **Admin routes** — 600 rpm + 100-req/10s burst (per `X-Admin-Key`)
- All rate limiters backed by Redis (`policy: redis`) for cross-pod consistency
- Added `request-size-limiting` plugin (1 MiB max payload) globally

#### Application Wiring (`src/main.rs`)

- `gateway_rate_limit` and `quota_enforcement` layers added to both v1 and
  v2 gateway stacks, running after `gateway_auth` (identity is resolved
  before limits are applied)
- `routes::rate_limit_analytics::router` mounted inside the v1 admin section

#### Module Registry

- `src/gateway/mod.rs` — exposes `rate_limiter`, `quota_manager`, `analytics`
  modules and re-exports all public symbols
- `src/routes/mod.rs` — registers `rate_limit_analytics` route module

---
