### PR TITLE
feat: enforce email uniqueness on creator registration

### DIFF
--- a/migrations/0068_add_unique_index_on_creators_email.down.sql
+++ b/migrations/0068_add_unique_index_on_creators_email.down.sql
@@ -1,0 +1,3 @@
+-- Rollback: remove unique index on creators.email
+
+DROP INDEX IF EXISTS idx_creators_email;

--- a/migrations/0068_add_unique_index_on_creators_email.sql
+++ b/migrations/0068_add_unique_index_on_creators_email.sql
@@ -1,0 +1,9 @@
+-- Migration: add unique partial index on creators.email
+--
+-- Ensures no two non-null emails are identical, preventing duplicate
+-- registration with the same email address.  NULL values are ignored so
+-- that creators without an email are not affected.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_creators_email
+    ON creators (email)
+    WHERE email IS NOT NULL;

--- a/src/controllers/creator_controller.rs
+++ b/src/controllers/creator_controller.rs
@@ -27,6 +27,22 @@ pub async fn create_creator(state: &AppState, req: CreateCreatorRequest) -> AppR
         }));
     }
 
+    // Check for duplicate email before inserting
+    if let Some(ref email) = req.email {
+        let exists = sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS(SELECT 1 FROM creators WHERE email = $1)",
+        )
+        .bind(email)
+        .fetch_one(&state.db)
+        .await?;
+        if exists {
+            return Err(AppError::Conflict {
+                code: "DUPLICATE_EMAIL",
+                message: "A creator with this email already exists".to_string(),
+            });
+        }
+    }
+
     let query = r#"
         INSERT INTO creators (id, username, wallet_address, email, created_at, bio, display_name, avatar_url, social_links, categories, tags)
         VALUES ($1, $2, $3, $4, NOW(), $5, $6, $7, $8::jsonb, $9, $10)

--- a/tests/creators_test.rs
+++ b/tests/creators_test.rs
@@ -54,6 +54,67 @@ async fn test_get_creator() {
 }
 
 #[tokio::test]
+async fn test_create_creator_duplicate_email() {
+    let pool = common::setup_test_db().await;
+    let (app, _) = common::create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    // First creator with email
+    let response = server
+        .post("/creators")
+        .json(&json!({
+            "username": "user_one",
+            "wallet_address": "GBCKL5SJHHGOU6JJVXIFVBV2VH6I5QMZ4Y2X6M27W6C3MJQZYMGMKGDN",
+            "email": "dup@example.com"
+        }))
+        .await;
+    response.assert_status(StatusCode::CREATED);
+
+    // Second creator with same email
+    let response = server
+        .post("/creators")
+        .json(&json!({
+            "username": "user_two",
+            "wallet_address": "GDZ5M7Y7V3ZKSJJXF7KCZ5Z5VZ3Y7V3ZKSJJXF7KCZ5Z5VZ3Y7V3ZKSA",
+            "email": "dup@example.com"
+        }))
+        .await;
+
+    response.assert_status(StatusCode::CONFLICT);
+
+    common::cleanup_test_db(&pool).await;
+}
+
+#[tokio::test]
+async fn test_create_creator_duplicate_email_without_email_ok() {
+    let pool = common::setup_test_db().await;
+    let (app, _) = common::create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    // First creator without email
+    let response = server
+        .post("/creators")
+        .json(&json!({
+            "username": "no_email_user",
+            "wallet_address": "GAX3B5XK7J3G6JJVXIFVBV2VH6I5QMZ4Y2X6M27W6C3MJQZYMGMKGDN",
+        }))
+        .await;
+    response.assert_status(StatusCode::CREATED);
+
+    // Second creator also without email should succeed (NULLs are distinct)
+    let response = server
+        .post("/creators")
+        .json(&json!({
+            "username": "no_email_user2",
+            "wallet_address": "GBY4C6YL8K4H7KKWYJGWCW3WIX7J6PZ5Z3X7N38X7D4NKQZWMGMKGDN",
+        }))
+        .await;
+    response.assert_status(StatusCode::CREATED);
+
+    common::cleanup_test_db(&pool).await;
+}
+
+#[tokio::test]
 async fn test_creator_not_found() {
     let pool = common::setup_test_db().await;
     let (app, _) = common::create_test_app(pool.clone()).await;


### PR DESCRIPTION
## Add Email Validation and Uniqueness Check on Creator Registration

### Problem
`CreateCreatorRequest` validates email format via the `validator` crate but does not check for uniqueness in the database. Two creators can register with the same email, breaking password reset flows and notifications.

### Changes

**1. Database migration (`migrations/0068_add_unique_index_on_creators_email.sql`)**
- Adds a partial unique index `idx_creators_email` on `creators(email)` with `WHERE email IS NOT NULL`
- Prevents duplicate non-null emails at the database level
- Allows multiple `NULL` emails (creators without an email address)

**2. Controller check (`src/controllers/creator_controller.rs:30-44`)**
- Before INSERT, checks if the email already exists via `SELECT EXISTS(...)`
- Returns **HTTP 409 Conflict** with code `DUPLICATE_EMAIL`
- Error message: *"A creator with this email already exists"* — does **not** leak which email is taken

**3. Tests (`tests/creators_test.rs`)**
- `test_create_creator_duplicate_email` — verifies 409 on duplicate email
- `test_create_creator_duplicate_email_without_email_ok` — verifies two NULL emails can coexist

### Testing
- Run `cargo test test_create_creator_duplicate_email` to verify the fix
- Run `cargo test test_create_creator_duplicate_email_without_email_ok` to verify NULL handling


Closes #304 