### PR TITLE
feat: persist campaign matching contributions to database

### DIFF
--- a/migrations/0069_create_campaign_contributions.down.sql
+++ b/migrations/0069_create_campaign_contributions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS campaign_contributions;

--- a/migrations/0069_create_campaign_contributions.sql
+++ b/migrations/0069_create_campaign_contributions.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS campaign_contributions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+    tip_id UUID NOT NULL REFERENCES tips(id) ON DELETE CASCADE,
+    matched_amount TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_campaign_contributions_campaign
+    ON campaign_contributions(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_campaign_contributions_tip
+    ON campaign_contributions(tip_id);

--- a/src/controllers/campaign_controller.rs
+++ b/src/controllers/campaign_controller.rs
@@ -3,7 +3,7 @@ use sqlx::{Postgres, Transaction};
 use uuid::Uuid;
 
 use crate::errors::AppResult;
-use crate::models::campaign::{Campaign, CampaignMatchResult};
+use crate::models::campaign::{Campaign, CampaignContribution, CampaignMatchResult, CampaignResponse};
 
 /// Find the highest-value active campaign for a creator and lock it for the duration of the tip update.
 pub async fn find_active_campaign_for_creator(
@@ -78,6 +78,18 @@ pub async fn apply_tip_matching_campaign(
 
     sqlx::query(
         r#"
+        INSERT INTO campaign_contributions (campaign_id, tip_id, matched_amount)
+        VALUES ($1, $2, $3)
+        "#,
+    )
+    .bind(campaign.id)
+    .bind(tip_id)
+    .bind(&matched_amount_str)
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query(
+        r#"
         UPDATE campaigns
         SET remaining_budget = (remaining_budget::numeric - $1::numeric)::text
         WHERE id = $2
@@ -93,4 +105,62 @@ pub async fn apply_tip_matching_campaign(
         sponsor_name: campaign.sponsor_name,
         matched_amount: matched_amount_str,
     }))
+}
+
+pub async fn list_campaigns_for_creator(
+    db: &sqlx::PgPool,
+    creator_username: &str,
+) -> AppResult<Vec<CampaignResponse>> {
+    let query = r#"
+        SELECT c.id,
+               c.sponsor_name,
+               c.creator_username,
+               c.match_ratio,
+               c.per_tip_cap,
+               c.total_budget,
+               c.remaining_budget,
+               COALESCE(cc.total_matched_amount, '0') AS total_matched_amount,
+               LEAST(
+                   COALESCE(cc.total_matched_amount::numeric, 0) / c.total_budget::numeric * 100.0,
+                   100.0
+               ) AS progress_pct,
+               c.active,
+               c.starts_at,
+               c.ends_at,
+               c.created_at
+        FROM campaigns c
+        LEFT JOIN (
+            SELECT campaign_id, SUM(matched_amount::numeric)::text AS total_matched_amount
+            FROM campaign_contributions
+            GROUP BY campaign_id
+        ) cc ON c.id = cc.campaign_id
+        WHERE c.creator_username = $1
+        ORDER BY c.created_at DESC
+        "#;
+
+    let campaigns = sqlx::query_as::<_, CampaignResponse>(query)
+        .bind(creator_username)
+        .fetch_all(db)
+        .await?;
+
+    Ok(campaigns)
+}
+
+pub async fn get_campaign_contributions(
+    db: &sqlx::PgPool,
+    campaign_id: Uuid,
+) -> AppResult<Vec<CampaignContribution>> {
+    let query = r#"
+        SELECT id, campaign_id, tip_id, matched_amount, created_at
+        FROM campaign_contributions
+        WHERE campaign_id = $1
+        ORDER BY created_at DESC
+        "#;
+
+    let contributions = sqlx::query_as::<_, CampaignContribution>(query)
+        .bind(campaign_id)
+        .fetch_all(db)
+        .await?;
+
+    Ok(contributions)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub fn create_app(state: Arc<AppState>) -> Router {
     // Read endpoints use the general limit and intelligent response caching.
     let read_routes = Router::new()
         .merge(routes::creators::read_router())
+        .merge(routes::campaigns::router())
         .merge(routes::deployment::router())
         .merge(routes::health::router())
         .merge(routes::leaderboard::router())

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,6 +391,7 @@ async fn main() -> anyhow::Result<()> {
                 .merge(
                     Router::new()
                         .merge(routes::creators::read_router())
+                        .merge(routes::campaigns::router())
                         .merge(routes::health::router())
                         .merge(routes::notifications::router())
                         .merge(routes::leaderboard::router())

--- a/src/models/campaign.rs
+++ b/src/models/campaign.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
@@ -17,12 +18,29 @@ pub struct Campaign {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
-pub struct CampaignMatch {
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, ToSchema)]
+pub struct CampaignContribution {
     pub id: Uuid,
     pub campaign_id: Uuid,
     pub tip_id: Uuid,
     pub matched_amount: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, ToSchema)]
+pub struct CampaignResponse {
+    pub id: Uuid,
+    pub sponsor_name: String,
+    pub creator_username: String,
+    pub match_ratio: String,
+    pub per_tip_cap: String,
+    pub total_budget: String,
+    pub remaining_budget: String,
+    pub total_matched_amount: String,
+    pub progress_pct: f64,
+    pub active: bool,
+    pub starts_at: Option<DateTime<Utc>>,
+    pub ends_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
 }
 

--- a/src/routes/campaigns.rs
+++ b/src/routes/campaigns.rs
@@ -1,0 +1,34 @@
+use axum::{extract::{Path, State}, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::controllers::campaign_controller;
+use crate::db::connection::AppState;
+use crate::errors::AppError;
+use crate::models::campaign::{CampaignContribution, CampaignResponse};
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/creators/:username/campaigns", get(list_creator_campaigns))
+        .route(
+            "/campaigns/:campaign_id/contributions",
+            get(get_campaign_contributions),
+        )
+}
+
+async fn list_creator_campaigns(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let campaigns = campaign_controller::list_campaigns_for_creator(&state.db, &username).await?;
+    Ok((StatusCode::OK, Json(campaigns)).into_response())
+}
+
+async fn get_campaign_contributions(
+    State(state): State<Arc<AppState>>,
+    Path(campaign_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let contributions =
+        campaign_controller::get_campaign_contributions(&state.db, campaign_id).await?;
+    Ok((StatusCode::OK, Json(contributions)).into_response())
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -10,6 +10,7 @@ pub mod cdn;
 pub mod collaboration;
 pub mod comments;
 pub mod creators;
+pub mod campaigns;
 pub mod currency;
 pub mod deprecation;
 pub mod deployment;


### PR DESCRIPTION
The implementation is complete. The changes made include:

Added campaign_contributions table: campaign_id, tip_id, matched_amount, created_at
Persisted each successful match in the transaction alongside the tip
Added GET /api/v1/campaigns/:id/contributions endpoint
Added campaign total_matched_amount computed from contributions
Exposed campaign progress in GET /api/v1/creators/:username/campaigns

CLoses #312 