### PR TITLE
[codex] Add creator stats endpoint

### DIFF
--- a/src/cache/keys.rs
+++ b/src/cache/keys.rs
@@ -11,6 +11,16 @@ pub fn creator_tips_pattern(username: &str) -> String {
     format!("creator:{}:tips:*", username)
 }
 
+/// Cache key for a creator's aggregate tip stats. TTL: 5 minutes.
+pub fn creator_stats(username: &str) -> String {
+    format!("creator:{}:stats", username)
+}
+
+/// Base pattern for a creator's stats cache entries.
+pub fn creator_stats_pattern(username: &str) -> String {
+    format!("creator:{}:stats*", username)
+}
+
 /// Cache key for a creator's tip list. TTL: 1 minute.
 pub fn creator_tips(
     username: &str,
@@ -76,5 +86,11 @@ mod tests {
         let key = creator_tips("alice", &params, &filters, &sort);
         assert!(key.starts_with("creator:alice:tips:"));
         assert!(key.contains("created_at"));
+    }
+
+    #[test]
+    fn creator_stats_key_is_scoped_to_creator() {
+        assert_eq!(creator_stats("alice"), "creator:alice:stats");
+        assert_eq!(creator_stats_pattern("alice"), "creator:alice:stats*");
     }
 }

--- a/src/controllers/stats_controller.rs
+++ b/src/controllers/stats_controller.rs
@@ -1,7 +1,54 @@
+use std::time::Duration;
+
+use serde::de::DeserializeOwned;
 use sqlx::PgPool;
 
-use crate::errors::AppResult;
-use crate::models::stats::{StatsQuery, TipDailyStat, TipSummary};
+use crate::cache::{keys, redis_client};
+use crate::db::connection::AppState;
+use crate::errors::{AppError, AppResult};
+use crate::models::stats::{
+    CreatorStats, StatsQuery, TipDailyStat, TipHistoryItem, TipSummary, TopSupporter,
+};
+
+const CREATOR_STATS_TTL_SECS: u64 = redis_client::TTL_CREATOR;
+
+#[derive(Debug, sqlx::FromRow)]
+struct CreatorStatsRow {
+    creator_username: String,
+    total_amount_xlm: String,
+    tip_count: i64,
+    unique_supporters: i64,
+    top_supporters: String,
+    tip_history: String,
+}
+
+impl CreatorStatsRow {
+    fn into_stats(self) -> AppResult<CreatorStats> {
+        let top_supporters =
+            parse_json_array::<TopSupporter>(&self.top_supporters, "top_supporters")?;
+        let tip_history = parse_json_array::<TipHistoryItem>(&self.tip_history, "tip_history")?;
+
+        Ok(CreatorStats {
+            creator_username: self.creator_username,
+            total_amount_xlm: self.total_amount_xlm,
+            tip_count: self.tip_count,
+            unique_supporters: self.unique_supporters,
+            top_supporters,
+            tip_history,
+        })
+    }
+}
+
+fn parse_json_array<T>(raw: &str, field: &'static str) -> AppResult<Vec<T>>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_str(raw).map_err(|e| {
+        AppError::internal_with_message(format!(
+            "Failed to decode creator stats field '{field}': {e}"
+        ))
+    })
+}
 
 pub async fn get_creator_summary(pool: &PgPool, username: &str) -> AppResult<TipSummary> {
     let summary = sqlx::query_as::<_, TipSummary>(
@@ -20,6 +67,125 @@ pub async fn get_creator_summary(pool: &PgPool, username: &str) -> AppResult<Tip
     .fetch_one(pool)
     .await?;
     Ok(summary)
+}
+
+pub async fn get_creator_stats(state: &AppState, username: &str) -> AppResult<CreatorStats> {
+    let cache_key = keys::creator_stats(username);
+
+    if let Some(conn) = state.redis.as_ref() {
+        let mut conn = conn.clone();
+        if let Some(stats) = redis_client::get::<CreatorStats>(&mut conn, &cache_key).await {
+            return Ok(stats);
+        }
+    }
+
+    if let Some(cache) = state.cache.as_ref() {
+        match cache.get::<CreatorStats>(&cache_key).await {
+            Ok(Some(stats)) => return Ok(stats),
+            Ok(None) => {}
+            Err(e) => tracing::warn!(error = %e, key = %cache_key, "Creator stats cache read failed"),
+        }
+    }
+
+    let pool = state.read_pool().await;
+    let row = sqlx::query_as::<_, CreatorStatsRow>(
+        r#"
+        WITH creator_tips AS (
+            SELECT
+                id,
+                amount::NUMERIC AS amount_xlm,
+                transaction_hash,
+                NULLIF(tipper_wallet, '') AS tipper_wallet,
+                created_at
+            FROM tips
+            WHERE creator_username = $1
+        ),
+        summary AS (
+            SELECT
+                COALESCE(SUM(amount_xlm), 0)::TEXT AS total_amount_xlm,
+                COUNT(*)::BIGINT AS tip_count,
+                COUNT(DISTINCT tipper_wallet)::BIGINT AS unique_supporters
+            FROM creator_tips
+        ),
+        ranked_supporters AS (
+            SELECT
+                tipper_wallet,
+                SUM(amount_xlm) AS total_amount_xlm,
+                COUNT(*)::BIGINT AS tip_count
+            FROM creator_tips
+            WHERE tipper_wallet IS NOT NULL
+            GROUP BY tipper_wallet
+            ORDER BY SUM(amount_xlm) DESC, COUNT(*) DESC, tipper_wallet ASC
+            LIMIT 5
+        ),
+        recent_tips AS (
+            SELECT
+                id,
+                amount_xlm,
+                transaction_hash,
+                tipper_wallet,
+                created_at
+            FROM creator_tips
+            ORDER BY created_at DESC, id DESC
+            LIMIT 20
+        )
+        SELECT
+            $1::TEXT AS creator_username,
+            summary.total_amount_xlm,
+            summary.tip_count,
+            summary.unique_supporters,
+            COALESCE((
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'tipper_wallet', tipper_wallet,
+                        'total_amount_xlm', total_amount_xlm::TEXT,
+                        'tip_count', tip_count
+                    )
+                    ORDER BY total_amount_xlm DESC, tip_count DESC, tipper_wallet ASC
+                )
+                FROM ranked_supporters
+            ), '[]'::jsonb)::TEXT AS top_supporters,
+            COALESCE((
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'id', id::TEXT,
+                        'amount_xlm', amount_xlm::TEXT,
+                        'transaction_hash', transaction_hash,
+                        'tipper_wallet', tipper_wallet,
+                        'created_at', to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+                    )
+                    ORDER BY created_at DESC, id DESC
+                )
+                FROM recent_tips
+            ), '[]'::jsonb)::TEXT AS tip_history
+        FROM summary
+        "#,
+    )
+    .bind(username)
+    .fetch_one(&pool)
+    .await?;
+
+    let stats = row.into_stats()?;
+
+    if let Some(conn) = state.redis.as_ref() {
+        let mut conn = conn.clone();
+        redis_client::set(&mut conn, &cache_key, &stats, redis_client::TTL_CREATOR).await;
+    }
+
+    if let Some(cache) = state.cache.as_ref() {
+        if let Err(e) = cache
+            .set(
+                &cache_key,
+                &stats,
+                Duration::from_secs(CREATOR_STATS_TTL_SECS),
+            )
+            .await
+        {
+            tracing::warn!(error = %e, key = %cache_key, "Creator stats cache write failed");
+        }
+    }
+
+    Ok(stats)
 }
 
 pub async fn get_daily_stats(
@@ -77,4 +243,32 @@ pub async fn aggregate_daily_stats(pool: &PgPool, username: &str) -> AppResult<(
     .execute(pool)
     .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creator_stats_row_decodes_json_aggregates() {
+        let row = CreatorStatsRow {
+            creator_username: "alice".to_string(),
+            total_amount_xlm: "12.5".to_string(),
+            tip_count: 2,
+            unique_supporters: 1,
+            top_supporters: r#"[{"tipper_wallet":"GABC","total_amount_xlm":"12.5","tip_count":2}]"#
+                .to_string(),
+            tip_history: r#"[{"id":"00000000-0000-0000-0000-000000000001","amount_xlm":"7.5","transaction_hash":"TX1","tipper_wallet":"GABC","created_at":"2026-07-04T00:00:00.000Z"}]"#
+                .to_string(),
+        };
+
+        let stats = row.into_stats().expect("row decodes");
+
+        assert_eq!(stats.creator_username, "alice");
+        assert_eq!(stats.total_amount_xlm, "12.5");
+        assert_eq!(stats.tip_count, 2);
+        assert_eq!(stats.unique_supporters, 1);
+        assert_eq!(stats.top_supporters[0].tipper_wallet, "GABC");
+        assert_eq!(stats.tip_history[0].amount_xlm, "7.5");
+    }
 }

--- a/src/controllers/tip_controller.rs
+++ b/src/controllers/tip_controller.rs
@@ -110,18 +110,7 @@ pub async fn record_tip_with_context(
     QueryLogger::log_query("INSERT tips + tip_logs (transaction)", duration);
     state.performance.track_query("tip_atomic_record", duration);
 
-    // Centralized cache invalidation for tips and leaderboards
-    if let Some(ref inv) = state.invalidator {
-        let tips_pattern = keys::creator_tips_pattern(&tip.creator_username);
-        let _ = inv.invalidate_pattern(&tips_pattern).await;
-        let _ = inv.invalidate_pattern("leaderboard:*").await;
-        let _ = inv
-            .invalidate_pattern(&keys::http_response_pattern("/tips"))
-            .await;
-        let _ = inv
-            .invalidate_pattern(&keys::http_response_pattern("/creators/"))
-            .await;
-    }
+    invalidate_tip_derived_caches(state, &tip.creator_username).await;
 
     // Main branch added Webhooks
     crate::webhooks::trigger_webhooks(
@@ -162,6 +151,28 @@ pub async fn record_tip_with_context(
     }
 
     Ok(tip)
+}
+
+pub async fn invalidate_tip_derived_caches(state: &AppState, username: &str) {
+    // Centralized cache invalidation for tips, stats, and leaderboards.
+    if let Some(ref inv) = state.invalidator {
+        let tips_pattern = keys::creator_tips_pattern(username);
+        let stats_pattern = keys::creator_stats_pattern(username);
+        let _ = inv.invalidate_pattern(&tips_pattern).await;
+        let _ = inv.invalidate_pattern(&stats_pattern).await;
+        let _ = inv.invalidate_pattern("leaderboard:*").await;
+        let _ = inv
+            .invalidate_pattern(&keys::http_response_pattern("/tips"))
+            .await;
+        let _ = inv
+            .invalidate_pattern(&keys::http_response_pattern("/creators/"))
+            .await;
+    }
+
+    if let Some(conn) = state.redis.as_ref() {
+        let mut conn = conn.clone();
+        redis_client::del_pattern(&mut conn, &keys::creator_stats_pattern(username)).await;
+    }
 }
 
 /// Lower-level tip recording that executes within an existing transaction.

--- a/src/models/stats.rs
+++ b/src/models/stats.rs
@@ -1,5 +1,6 @@
-use chrono::NaiveDate;
+use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct TipDailyStat {
@@ -18,6 +19,32 @@ pub struct TipSummary {
     pub total_amount: String,
     pub avg_amount: String,
     pub max_amount: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TopSupporter {
+    pub tipper_wallet: String,
+    pub total_amount_xlm: String,
+    pub tip_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TipHistoryItem {
+    pub id: Uuid,
+    pub amount_xlm: String,
+    pub transaction_hash: String,
+    pub tipper_wallet: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CreatorStats {
+    pub creator_username: String,
+    pub total_amount_xlm: String,
+    pub tip_count: i64,
+    pub unique_supporters: i64,
+    pub top_supporters: Vec<TopSupporter>,
+    pub tip_history: Vec<TipHistoryItem>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/routes/stats.rs
+++ b/src/routes/stats.rs
@@ -14,9 +14,18 @@ use crate::models::stats::StatsQuery;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
+        .route("/creators/:username/stats", get(get_stats))
         .route("/creators/:username/stats/summary", get(get_summary))
         .route("/creators/:username/stats/daily", get(get_daily))
         .route("/creators/:username/stats/aggregate", post(aggregate))
+}
+
+async fn get_stats(
+    State(state): State<Arc<AppState>>,
+    Path(username): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let stats = stats_controller::get_creator_stats(&state, &username).await?;
+    Ok((StatusCode::OK, Json(stats)))
 }
 
 async fn get_summary(

--- a/src/services/tip_service.rs
+++ b/src/services/tip_service.rs
@@ -65,7 +65,7 @@ impl TipService {
         requests: Vec<RecordTipRequest>,
     ) -> AppResult<Vec<Tip>> {
         let pool = state.db.clone();
-        with_db_retry(&pool, 3, |pool| {
+        let tips = with_db_retry(&pool, 3, |pool| {
             let requests = requests.clone();
             let state = state.clone();
             Box::pin(async move {
@@ -102,6 +102,12 @@ impl TipService {
                 .await
             })
         })
-        .await
+        .await?;
+
+        for tip in &tips {
+            tip_controller::invalidate_tip_derived_caches(state, &tip.creator_username).await;
+        }
+
+        Ok(tips)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `GET /creators/:username/stats` with total XLM tipped, tip count, unique supporters, top supporters, and recent tip history.
- Uses a single CTE-backed Postgres query for the stats payload.
- Caches stats in Redis for 5 minutes and invalidates the creator stats cache after new tips, including bulk tip recording.

## Notes
- The requested `tips(creator_username, created_at)` index already exists in the current migration set as `idx_tips_creator_created` and `idx_tips_creator_recent`, so this avoids adding a duplicate index.

## Validation
- `git diff --check`
- Not run: `cargo fmt` / `cargo test` because this environment does not have `cargo`, `rustc`, `rustup`, Docker, or `psql` installed.

Closes #308