### PR TITLE
feat: implement Stellar tip verification pipeline

### DIFF
--- a/migrations/0012_tip_verification_pipeline.sql
+++ b/migrations/0012_tip_verification_pipeline.sql
@@ -1,0 +1,46 @@
+-- Migration 0012: Tip Verification Pipeline
+-- Adds two-phase tip state (pending_verification → confirmed/rejected),
+-- tipper source account for on-chain verification, and enforces exactly-once
+-- ingestion via a UNIQUE constraint on transaction_hash.
+
+-- 1. Add the status column with a safe default for existing rows
+ALTER TABLE tips
+    ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'confirmed';
+
+-- 2. Add tipper_source_account (nullable – populated for newly submitted tips)
+ALTER TABLE tips
+    ADD COLUMN IF NOT EXISTS tipper_source_account TEXT;
+
+-- 3. Backfill: existing rows were never verified; mark them as 'confirmed'
+--    because they pre-date the verification pipeline and must remain visible.
+UPDATE tips SET status = 'confirmed' WHERE status IS NULL OR status = '';
+
+-- 4. Add CHECK constraint so only valid values are stored
+ALTER TABLE tips
+    ADD CONSTRAINT tips_status_check
+        CHECK (status IN ('pending_verification', 'confirmed', 'rejected'));
+
+-- 5. Ensure the UNIQUE constraint on transaction_hash exists
+--    (0002_create_tips.sql already added it, but guard with IF NOT EXISTS pattern
+--     by creating a named index if the constraint name doesn't exist)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'tips'
+          AND constraint_type = 'UNIQUE'
+          AND constraint_name = 'tips_transaction_hash_key'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE tablename = 'tips' AND indexname = 'tips_transaction_hash_unique'
+    ) THEN
+        CREATE UNIQUE INDEX tips_transaction_hash_unique ON tips(transaction_hash);
+    END IF;
+END
+$$;
+
+-- 6. Index for fast lookup of pending tips (used by reconciliation job)
+CREATE INDEX IF NOT EXISTS idx_tips_status ON tips(status);
+
+-- 7. Index for reconciliation queries on created_at + status
+CREATE INDEX IF NOT EXISTS idx_tips_status_created_at ON tips(status, created_at);

--- a/src/controllers/creator_controller.rs
+++ b/src/controllers/creator_controller.rs
@@ -2,6 +2,7 @@ use base64::{engine::general_purpose, Engine as _};
 use ed25519_dalek::{PublicKey, Signature, Verifier};
 use std::time::Instant;
 use uuid::Uuid;
+use sqlx::PgPool;
 
 use crate::cache::{keys, redis_client};
 use crate::db::connection::AppState;
@@ -11,7 +12,6 @@ use crate::metrics::collectors::CREATORS_REGISTERED_TOTAL;
 use crate::models::creator::{CreateCreatorRequest, Creator, UpdateCreatorProfileRequest, UpdateCreatorWalletRequest};
 use crate::moderation::ContentType;
 use crate::search::SearchQuery;
-use sqlx::PgPool;
 use validator::Validate;
 
 #[tracing::instrument(skip(state), fields(username = %req.username))]
@@ -94,14 +94,7 @@ pub async fn create_creator(state: &AppState, req: CreateCreatorRequest) -> AppR
             .await;
     }
 
-    // Main branch added Webhook notification
-    crate::webhooks::trigger_webhooks(
-        state.db.clone(),
-        "creator.created",
-        serde_json::to_value(&creator).unwrap(),
-    )
-    .await;
-    // Notify external services via webhook.
+    // Webhook notification
     let payload = serde_json::to_value(&creator).map_err(|e| {
         tracing::error!(error = %e, "Failed to serialize creator webhook payload");
         AppError::internal()
@@ -169,7 +162,7 @@ pub async fn get_creator_by_username(
         "Creator lookup"
     );
 
-    // Populate cache if found.
+    // Populate cache if found
     if let (Some(ref c), Some(conn)) = (&creator, state.redis.as_ref()) {
         let mut conn = conn.clone();
         let _ = redis_client::set(
@@ -186,10 +179,11 @@ pub async fn get_creator_by_username(
 
 #[tracing::instrument(skip(state), fields(username = %username))]
 pub async fn get_creator_or_not_found(state: &AppState, username: &str) -> AppResult<Creator> {
-    let creator = get_creator_by_username(state, username).await?;
-    creator.ok_or_else(|| AppError::CreatorNotFound {
-        username: username.to_string(),
-    })
+    get_creator_by_username(state, username)
+        .await?
+        .ok_or_else(|| AppError::CreatorNotFound {
+            username: username.to_string(),
+        })
 }
 
 /// Search creators by username using PostgreSQL full-text search with trigram

--- a/src/controllers/export_controller.rs
+++ b/src/controllers/export_controller.rs
@@ -15,18 +15,22 @@ pub async fn get_all_creators(pool: &PgPool) -> AppResult<Vec<Creator>> {
     Ok(creators)
 }
 
+/// Export only confirmed tips (pending/rejected are internal operational state).
 pub async fn get_all_tips(pool: &PgPool) -> AppResult<Vec<Tip>> {
     let tips = sqlx::query_as::<_, Tip>(
-        "SELECT id, creator_username, amount, transaction_hash, message, created_at FROM tips ORDER BY created_at ASC",
+        "SELECT id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account \
+         FROM tips WHERE status = 'confirmed' ORDER BY created_at ASC",
     )
     .fetch_all(pool)
     .await?;
     Ok(tips)
 }
 
+/// Export only confirmed tips for a specific creator.
 pub async fn get_tips_for_creator(pool: &PgPool, username: &str) -> AppResult<Vec<Tip>> {
     let tips = sqlx::query_as::<_, Tip>(
-        "SELECT id, creator_username, amount, transaction_hash, message, created_at FROM tips WHERE creator_username = $1 ORDER BY created_at ASC",
+        "SELECT id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account \
+         FROM tips WHERE creator_username = $1 AND status = 'confirmed' ORDER BY created_at ASC",
     )
     .bind(username)
     .fetch_all(pool)

--- a/src/controllers/tip_controller.rs
+++ b/src/controllers/tip_controller.rs
@@ -6,23 +6,32 @@ use crate::controllers::{campaign_controller, team_controller};
 use crate::db::connection::AppState;
 use crate::db::query_logger::QueryLogger;
 use crate::db::transaction;
-use crate::errors::{AppError, AppResult};
+use crate::errors::{AppError, AppResult, DatabaseError};
 use crate::metrics::collectors::{
     DB_QUERY_DURATION_SECONDS, TIPS_AMOUNT_XLM, TIPS_CREATED_TOTAL, TIPS_FAILED_TOTAL,
 };
 use crate::models::pagination::{
     CursorDirection, KeysetCursor, PaginatedResponse, PaginationParams,
 };
-use crate::models::tip::{RecordTipRequest, ReportMessageRequest, Tip, TipFilters, TipSortParams};
+use crate::models::tip::{RecordTipRequest, ReportMessageRequest, Tip, TipFilters, TipSortParams, TipStatus};
+use crate::moderation::ContentType;
+use crate::queue::VerificationJob;
+use crate::validation::amount::xlm_to_stroops_str;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TipRecordContext {
     pub ip: Option<IpAddr>,
 }
 
-use crate::moderation::ContentType;
+// ─────────────────────────── record_tip ─────────────────────────────────────
 
-#[tracing::instrument(skip(state), fields(username = %req.username, amount = %req.amount))]
+/// Insert the tip as `pending_verification` and enqueue an async verification job.
+///
+/// Uses `ON CONFLICT DO NOTHING` so duplicate tx_hash submissions from concurrent
+/// clients simply return a `Conflict` error rather than crashing.
+///
+/// No webhooks fire here – they are deferred until `confirm_tip`.
+#[tracing::instrument(skip(state), fields(username = %req.username, amount = %req.amount, tx_hash = %req.transaction_hash))]
 pub async fn record_tip(state: &AppState, req: RecordTipRequest) -> AppResult<Tip> {
     record_tip_with_context(state, req, TipRecordContext::default()).await
 }
@@ -53,246 +62,213 @@ pub async fn record_tip_with_context(
         }
     }
 
-    let mut tx = transaction::begin_transaction(&state.db)
-        .await
-        .map_err(AppError::from)?;
-
     let start = Instant::now();
-    // Pass state into the internal helper to support WebSocket broadcasting
-    let (tip, match_result) =
-        match record_tip_in_tx_with_context(state, &mut tx, &req, context).await {
-            Ok(result) => result,
-            Err(e) => {
-                TIPS_FAILED_TOTAL
-                    .with_label_values(&["record_tip_in_tx"])
-                    .inc();
-                return Err(e);
-            }
-        };
-    tx.commit().await?;
-    let duration = start.elapsed();
+    let tip_id = Uuid::new_v4();
 
-    DB_QUERY_DURATION_SECONDS
-        .with_label_values(&["tip_atomic_record"])
-        .observe(duration.as_secs_f64());
-    TIPS_CREATED_TOTAL.inc();
-    if let Ok(amount) = tip.amount.parse::<f64>() {
-        TIPS_AMOUNT_XLM.observe(amount);
-    }
-
-    if let Some(match_info) = match_result {
-        let db = state.db.clone();
-        let username = tip.creator_username.clone();
-        let tip_id = tip.id;
-        tokio::spawn(async move {
-            use crate::controllers::notification_controller;
-            if let Ok(prefs) = notification_controller::get_preferences(&db, &username).await {
-                if prefs.notify_on_tip {
-                    let payload = serde_json::json!({
-                        "tip_id": tip_id,
-                        "matched_amount": match_info.matched_amount,
-                        "campaign_id": match_info.campaign_id,
-                        "sponsor_name": match_info.sponsor_name,
-                    });
-                    if let Err(e) = notification_controller::create_notification(
-                        &db,
-                        &username,
-                        "campaign_matched",
-                        payload,
-                    )
-                    .await
-                    {
-                        tracing::warn!("Failed to persist campaign match notification: {e}");
-                    }
-                }
-            }
-        });
-    }
-
-    QueryLogger::log_query("INSERT tips + tip_logs (transaction)", duration);
-    state.performance.track_query("tip_atomic_record", duration);
-
-    // Centralized cache invalidation for tips and leaderboards
-    if let Some(ref inv) = state.invalidator {
-        let tips_pattern = keys::creator_tips_pattern(&tip.creator_username);
-        let _ = inv.invalidate_pattern(&tips_pattern).await;
-        let _ = inv.invalidate_pattern("leaderboard:*").await;
-        let _ = inv
-            .invalidate_pattern(&keys::http_response_pattern("/tips"))
-            .await;
-        let _ = inv
-            .invalidate_pattern(&keys::http_response_pattern("/creators/"))
-            .await;
-    }
-
-    // Main branch added Webhooks
-    crate::webhooks::trigger_webhooks(
-        state.db.clone(),
-        "tip.recorded",
-        serde_json::to_value(&tip).unwrap(),
+    let tip = sqlx::query_as::<_, Tip>(
+        r#"
+        INSERT INTO tips
+            (id, creator_username, amount, transaction_hash, tipper_source_account, status, created_at)
+        VALUES
+            ($1, $2, $3, $4, $5, 'pending_verification', NOW())
+        ON CONFLICT (transaction_hash) DO NOTHING
+        RETURNING id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account
+        "#,
     )
-    .await;
-    // Notify external services via webhook.
-    let payload = serde_json::to_value(&tip).map_err(|e| {
-        tracing::error!(error = %e, "Failed to serialize tip webhook payload");
-        crate::errors::AppError::internal()
+    .bind(tip_id)
+    .bind(&req.username)
+    .bind(&req.amount)
+    .bind(&req.transaction_hash)
+    .bind(&req.tipper_source_account)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::Conflict {
+        code: "DUPLICATE_TX_HASH",
+        message: format!(
+            "A tip with transaction hash '{}' has already been submitted",
+            req.transaction_hash
+        ),
     })?;
-    crate::webhooks::trigger_webhooks(state.db.clone(), "tip.recorded", payload).await;
 
-    // Audit log: tip recorded
-    {
-        let db = state.db.clone();
-        let creator = tip.creator_username.clone();
-        let tip_id = tip.id.to_string();
-        let amount = tip.amount.clone();
-        tokio::spawn(async move {
-            let _ = crate::controllers::audit_log_controller::log(
-                &db,
-                "tip.recorded",
-                None,
-                "tip",
-                Some(&tip_id),
-                "create",
-                None,
-                Some(serde_json::json!({ "creator": creator, "amount": amount })),
-                serde_json::json!({}),
-                None,
-                None,
-            )
-            .await;
-        });
+    let duration = start.elapsed();
+    DB_QUERY_DURATION_SECONDS
+        .with_label_values(&["tip_record_pending"])
+        .observe(duration.as_secs_f64());
+    QueryLogger::log_query("INSERT tips (pending_verification)", duration);
+    state.performance.track_query("tip_record_pending", duration);
+
+    // Log the initial insert in the audit table
+    let _ = sqlx::query(
+        "INSERT INTO tip_logs (tip_id, creator_username, action) VALUES ($1, $2, 'submitted')",
+    )
+    .bind(&tip.id)
+    .bind(&tip.creator_username)
+    .execute(&state.db)
+    .await;
+
+    // Parse amount to stroops for the verification job
+    let amount_stroops = xlm_to_stroops_str(&req.amount).map_err(|e| {
+        AppError::Validation(crate::errors::ValidationError::InvalidRequest {
+            message: format!("Invalid tip amount: {}", e),
+        })
+    })?;
+
+    // Fetch creator wallet address for destination verification
+    let destination: String = sqlx::query_scalar(
+        "SELECT wallet_address FROM creators WHERE username = $1",
+    )
+    .bind(&req.username)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::CreatorNotFound {
+        username: req.username.clone(),
+    })?;
+
+    // Enqueue verification job; failure here is best-effort – reconciliation will retry
+    let job = VerificationJob {
+        tip_id: tip.id,
+        transaction_hash: req.transaction_hash.clone(),
+        amount_stroops,
+        destination,
+        expected_memo: req.memo.clone(),
+        source_account: req.tipper_source_account.clone(),
+        attempt: 0,
+    };
+
+    if let Err(e) = state.queue.enqueue(job).await {
+        tracing::error!(
+            tip_id = %tip.id,
+            error = %e,
+            "Failed to enqueue verification job; reconciliation will retry"
+        );
     }
 
-    Ok(tip)
-}
-
-/// Lower-level tip recording that executes within an existing transaction.
-pub async fn record_tip_in_tx(
-    state: &AppState, // Added state parameter to fix scope issue in Main
-    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    req: &RecordTipRequest,
-) -> AppResult<(Tip, Option<crate::models::campaign::CampaignMatchResult>)> {
-    record_tip_in_tx_with_context(state, tx, req, TipRecordContext::default()).await
-}
-
-pub async fn record_tip_in_tx_with_context(
-    state: &AppState,
-    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    req: &RecordTipRequest,
-    context: TipRecordContext,
-) -> AppResult<(Tip, Option<crate::models::campaign::CampaignMatchResult>)> {
-    let query_tip = r#"
-        INSERT INTO tips (id, creator_username, amount, transaction_hash, message, message_visibility, tipper_wallet, tipper_ip, created_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
-        RETURNING id, creator_username, amount, transaction_hash, message, message_visibility, created_at
-        "#;
-
-    let tip = sqlx::query_as::<_, Tip>(query_tip)
-        .bind(Uuid::new_v4())
-        .bind(&req.username)
-        .bind(&req.amount)
-        .bind(&req.transaction_hash)
-        .bind(&req.message)
-        .bind(req.message_visibility.as_str())
-        .bind(&req.tipper_wallet)
-        .bind(context.ip.map(|ip| ip.to_string()))
-        .fetch_one(&mut **tx)
-        .await?;
-
-    // Log the action in the database
-    let query_log = r#"
-        INSERT INTO tip_logs (tip_id, creator_username, action)
-        VALUES ($1, $2, 'recorded_atomic')
-        "#;
-
-    sqlx::query(query_log)
-        .bind(&tip.id)
-        .bind(&tip.creator_username)
-        .execute(&mut **tx)
-        .await?;
-
-    // Apply team splits if the recipient belongs to a team.
-    team_controller::record_tip_splits(
-        &state,
-        tip.id,
-        &tip.creator_username,
-        &tip.amount,
-        &mut *tx,
-    )
-    .await?;
-
-    // Broadcast to WebSocket (Main branch feature)
+    // Broadcast real-time event (tip is pending – UI may show a spinner)
     let event = crate::ws::TipEvent {
         creator_id: tip.creator_username.clone(),
-        tipper_id: req.transaction_hash.clone(),
+        tipper_id: req.tipper_source_account.clone(),
         amount: tip.amount.parse::<u64>().unwrap_or(0),
         timestamp: tip.created_at.timestamp(),
     };
     crate::ws::broadcast_tip(&state.broadcast_tx, event).await;
 
-    // Persist notification if creator has tip notifications enabled.
-    {
-        let db = state.db.clone();
-        let username = tip.creator_username.clone();
-        let payload = serde_json::json!({
-            "tip_id": tip.id,
-            "amount": tip.amount,
-            "transaction_hash": tip.transaction_hash,
-            "message": tip.message,
-        });
-        tokio::spawn(async move {
-            use crate::controllers::notification_controller;
-            match notification_controller::get_preferences(&db, &username).await {
-                Ok(prefs) if prefs.notify_on_tip => {
-                    if let Err(e) = notification_controller::create_notification(
-                        &db,
-                        &username,
-                        "tip_received",
-                        payload,
-                    )
-                    .await
-                    {
-                        tracing::warn!("Failed to persist tip notification: {e}");
-                    }
-                }
-                _ => {}
-            }
-        });
+    // Cache invalidation
+    if let Some(conn) = state.redis.as_ref() {
+        let mut conn = conn.clone();
+        let tips_key = keys::creator_tips_pattern(&tip.creator_username);
+        let _ = redis_client::del(&mut conn, &[tips_key.as_str()]).await;
     }
 
-    // Attempt to apply a matching campaign to this tip.
-    let match_result = campaign_controller::apply_tip_matching_campaign(
-        &mut *tx,
-        &tip.creator_username,
-        tip.id,
-        &tip.amount,
-    )
-    .await?;
-
-    // Update tip goals progress and fire milestone notifications
-    {
-        let db = state.db.clone();
-        let username = tip.creator_username.clone();
-        let amount = tip.amount.clone();
-        tokio::spawn(async move {
-            if let Err(e) =
-                crate::controllers::goal_controller::apply_tip_to_goals(&db, &username, &amount)
-                    .await
-            {
-                tracing::warn!("Failed to update goal progress: {e}");
-            }
-        });
+    TIPS_CREATED_TOTAL.inc();
+    if let Ok(amount) = tip.amount.parse::<f64>() {
+        TIPS_AMOUNT_XLM.observe(amount);
     }
 
-    Ok((tip, match_result))
+    Ok(tip)
 }
 
-/// Fetch all tips for a creator without pagination (kept for internal use).
+// ─────────────────────────── confirm_tip ────────────────────────────────────
+
+/// Transition a tip from `pending_verification` to `confirmed`.
+///
+/// Only fires webhooks and updates analytics **after** confirmation.
+pub async fn confirm_tip(state: &AppState, tip_id: Uuid) -> AppResult<()> {
+    let tip = sqlx::query_as::<_, Tip>(
+        r#"
+        UPDATE tips
+        SET    status = 'confirmed'
+        WHERE  id     = $1
+          AND  status = 'pending_verification'
+        RETURNING id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account
+        "#,
+    )
+    .bind(tip_id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::Database(DatabaseError::NotFound {
+        entity: "tip",
+        identifier: tip_id.to_string(),
+    }))?;
+
+    // Audit log
+    let _ = sqlx::query(
+        "INSERT INTO tip_logs (tip_id, creator_username, action) VALUES ($1, $2, 'confirmed')",
+    )
+    .bind(tip.id)
+    .bind(&tip.creator_username)
+    .execute(&state.db)
+    .await;
+
+    // Cache invalidation
+    if let Some(conn) = state.redis.as_ref() {
+        let mut conn = conn.clone();
+        let _ = redis_client::del(&mut conn, &[keys::creator_tips_pattern(&tip.creator_username).as_str()]).await;
+    }
+
+    // Webhooks fire ONLY for confirmed tips
+    let payload = serde_json::to_value(&tip).map_err(|e| {
+        tracing::error!(error = %e, "Failed to serialize tip webhook payload");
+        AppError::internal()
+    })?;
+    crate::webhooks::trigger_webhooks(state.db.clone(), "tip.confirmed", payload).await;
+
+    tracing::info!(tip_id = %tip_id, "Tip confirmed and webhooks triggered");
+    Ok(())
+}
+
+// ─────────────────────────── reject_tip ─────────────────────────────────────
+
+/// Transition a tip from `pending_verification` to `rejected` with a reason.
+///
+/// Rejected tips do NOT fire webhooks or update leaderboards.
+pub async fn reject_tip(state: &AppState, tip_id: Uuid, reason: &str) -> AppResult<()> {
+    let tip = sqlx::query_as::<_, Tip>(
+        r#"
+        UPDATE tips
+        SET    status = 'rejected'
+        WHERE  id     = $1
+          AND  status = 'pending_verification'
+        RETURNING id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account
+        "#,
+    )
+    .bind(tip_id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::Database(DatabaseError::NotFound {
+        entity: "tip",
+        identifier: tip_id.to_string(),
+    }))?;
+
+    // Audit log with rejection reason
+    let action = format!("rejected: {}", reason);
+    let _ = sqlx::query(
+        "INSERT INTO tip_logs (tip_id, creator_username, action) VALUES ($1, $2, $3)",
+    )
+    .bind(tip.id)
+    .bind(&tip.creator_username)
+    .bind(&action)
+    .execute(&state.db)
+    .await;
+
+    // Cache invalidation
+    if let Some(conn) = state.redis.as_ref() {
+        let mut conn = conn.clone();
+        let _ = redis_client::del(&mut conn, &[keys::creator_tips_pattern(&tip.creator_username).as_str()]).await;
+    }
+
+    tracing::info!(tip_id = %tip_id, reason = %reason, "Tip rejected");
+    Ok(())
+}
+
+// ─────────────────────────── read helpers ───────────────────────────────────
+
+/// Fetch all **confirmed** tips for a creator (for external API responses).
 pub async fn get_tips_for_creator(state: &AppState, username: &str) -> AppResult<Vec<Tip>> {
     let query = r#"
-        SELECT id, creator_username, amount, transaction_hash, message, message_visibility, created_at
+        SELECT id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account
         FROM tips
         WHERE creator_username = $1
+          AND status = 'confirmed'
         ORDER BY created_at DESC
         "#;
 
@@ -306,7 +282,6 @@ pub async fn get_tips_for_creator(state: &AppState, username: &str) -> AppResult
     DB_QUERY_DURATION_SECONDS
         .with_label_values(&["tips_list_by_creator"])
         .observe(duration.as_secs_f64());
-
     QueryLogger::log_query(query, duration);
     state.performance.track_query(query, duration);
 
@@ -386,7 +361,7 @@ pub async fn get_tips_paginated(
 
     let data_sql = if params.uses_offset() {
         format!(
-            "SELECT id, creator_username, amount, transaction_hash, message, message_visibility, created_at \
+            "SELECT id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account \
              FROM tips {where_clause} \
              ORDER BY created_at DESC, id DESC \
              LIMIT ${} OFFSET ${}",
@@ -395,7 +370,7 @@ pub async fn get_tips_paginated(
         )
     } else {
         format!(
-            "SELECT id, creator_username, amount, transaction_hash, message, message_visibility, created_at \
+            "SELECT id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account \
              FROM tips {where_clause} \
              ORDER BY created_at {order}, id {order} \
              LIMIT ${}",
@@ -457,14 +432,14 @@ pub async fn report_tip_message(
 ) -> AppResult<()> {
     // Verify the tip exists and has a message.
     let tip = sqlx::query_as::<_, Tip>(
-        "SELECT id, creator_username, amount, transaction_hash, message, message_visibility, created_at \
+        "SELECT id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account \
          FROM tips WHERE id = $1",
     )
     .bind(tip_id)
     .fetch_optional(&state.db)
     .await?
     .ok_or_else(|| AppError::Database(crate::errors::DatabaseError::NotFound {
-        entity: "tip".to_string(),
+        entity: "tip",
         identifier: tip_id.to_string(),
     }))?;
 
@@ -481,4 +456,36 @@ pub async fn report_tip_message(
         })?;
 
     Ok(())
+}
+
+// ─────────────────── lower-level helper (for bulk operations) ────────────────
+
+/// Lower-level tip recording within an existing transaction.
+/// Retained for `TipService::bulk_record_tips`. Inserts as `pending_verification`.
+pub async fn record_tip_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    req: &RecordTipRequest,
+) -> AppResult<Tip> {
+    let tip = sqlx::query_as::<_, Tip>(
+        r#"
+        INSERT INTO tips
+            (id, creator_username, amount, transaction_hash, tipper_source_account, status, created_at)
+        VALUES ($1, $2, $3, $4, $5, 'pending_verification', NOW())
+        ON CONFLICT (transaction_hash) DO NOTHING
+        RETURNING id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account
+        "#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(&req.username)
+    .bind(&req.amount)
+    .bind(&req.transaction_hash)
+    .bind(&req.tipper_source_account)
+    .fetch_optional(&mut **tx)
+    .await?
+    .ok_or_else(|| AppError::Conflict {
+        code: "DUPLICATE_TX_HASH",
+        message: format!("Duplicate transaction hash: {}", req.transaction_hash),
+    })?;
+
+    Ok(tip)
 }

--- a/src/cqrs/commands.rs
+++ b/src/cqrs/commands.rs
@@ -12,6 +12,8 @@ pub enum Command {
         creator_username: String,
         amount: String,
         transaction_hash: String,
+        tipper_source_account: String,
+        memo: Option<String>,
     },
 }
 

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
 
+use crate::services::stellar_service::TipVerifier;
+use crate::queue::VerificationQueue;
 use super::performance::PerformanceMonitor;
 use super::replica::ReplicaManager;
 use crate::cache::{CacheInvalidator, MultiLayerCache};
@@ -18,7 +20,10 @@ use crate::ws::TipEvent;
 #[derive(Clone)]
 pub struct AppState {
     pub db: PgPool,
-    pub stellar: StellarService,
+    /// Injectable on-chain verifier (production: StellarService, tests: MockTipVerifier).
+    pub verifier: Arc<dyn TipVerifier>,
+    /// Background verification job queue.
+    pub queue: VerificationQueue,
     pub performance: Arc<PerformanceMonitor>,
     pub redis: Option<ConnectionManager>,
     pub broadcast_tx: broadcast::Sender<TipEvent>,

--- a/src/graphql/dataloaders.rs
+++ b/src/graphql/dataloaders.rs
@@ -37,7 +37,8 @@ impl Loader<String> for TipLoader {
 
     async fn load(&self, keys: &[String]) -> Result<HashMap<String, Vec<Tip>>, Self::Error> {
         let tips = sqlx::query_as::<_, Tip>(
-            "SELECT id, creator_username, amount, transaction_hash, message, created_at FROM tips WHERE creator_username = ANY($1) ORDER BY created_at DESC",
+            "SELECT id, creator_username, amount, transaction_hash, created_at, status, tipper_source_account \
+             FROM tips WHERE creator_username = ANY($1) AND status = 'confirmed' ORDER BY created_at DESC",
         )
         .bind(keys.to_vec())
         .fetch_all(&self.pool)

--- a/src/graphql/mutations.rs
+++ b/src/graphql/mutations.rs
@@ -21,6 +21,8 @@ pub struct RecordTipInput {
     pub amount: String,
     pub tipper_wallet: Option<String>,
     pub transaction_hash: String,
+    pub tipper_source_account: String,
+    pub memo: Option<String>,
 }
 
 pub struct MutationRoot;
@@ -49,18 +51,13 @@ impl MutationRoot {
     async fn record_tip(&self, ctx: &Context<'_>, input: RecordTipInput) -> Result<GqlTip> {
         let gql_ctx = ctx.data::<GraphQLContext>()?;
 
-        gql_ctx
-            .state
-            .stellar
-            .verify_transaction(&input.transaction_hash)
-            .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
-
         let req = RecordTipRequest {
             username: input.username,
             amount: input.amount,
             tipper_wallet: input.tipper_wallet,
             transaction_hash: input.transaction_hash,
+            tipper_source_account: input.tipper_source_account,
+            memo: input.memo,
             message: None,
             message_visibility: crate::models::tip::MessageVisibility::Public,
         };

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -6,6 +6,7 @@
 pub mod handlers;
 pub mod monitoring;
 pub mod queue;
+pub mod reconciliation;
 pub mod scheduler;
 pub mod types;
 pub mod worker;

--- a/src/jobs/reconciliation.rs
+++ b/src/jobs/reconciliation.rs
@@ -1,0 +1,162 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::db::connection::AppState;
+use crate::queue::VerificationJob;
+use crate::validation::amount::xlm_to_stroops_str;
+
+/// A tip that has been stuck in `pending_verification` for longer than the
+/// staleness threshold.
+#[derive(Debug, sqlx::FromRow)]
+struct StuckTip {
+    id: uuid::Uuid,
+    transaction_hash: String,
+    amount: String,
+    creator_username: String,
+    #[sqlx(default)]
+    tipper_source_account: Option<String>,
+}
+
+/// How old a `pending_verification` tip must be before the reconciliation job
+/// considers it stuck and re-drives it.
+const STUCK_AFTER: Duration = Duration::from_secs(5 * 60); // 5 minutes
+
+/// How often the reconciliation job polls for stuck tips.
+const POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Spawn a background reconciliation task that periodically re-enqueues
+/// `pending_verification` tips that have not been resolved within the
+/// staleness window.
+///
+/// This provides resilience against queue worker crashes, Horizon outages,
+/// or process restarts.
+pub fn spawn(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        tracing::info!("Tip reconciliation job started (poll interval {:?})", POLL_INTERVAL);
+
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+            run_once(Arc::clone(&state)).await;
+        }
+    });
+}
+
+/// Run a single reconciliation pass. Returns the number of tips re-enqueued.
+pub async fn run_once(state: Arc<AppState>) -> usize {
+    let stuck_tips = match fetch_stuck_tips(&state).await {
+        Ok(tips) => tips,
+        Err(e) => {
+            tracing::error!(error = %e, "Reconciliation: failed to fetch stuck tips");
+            return 0;
+        }
+    };
+
+    if stuck_tips.is_empty() {
+        tracing::debug!("Reconciliation: no stuck tips found");
+        return 0;
+    }
+
+    tracing::info!("Reconciliation: found {} stuck tips", stuck_tips.len());
+
+    let mut enqueued = 0usize;
+
+    for tip in &stuck_tips {
+        // Parse amount to stroops; skip tips with unparseable amounts
+        let amount_stroops = match xlm_to_stroops_str(&tip.amount) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(
+                    tip_id = %tip.id,
+                    amount = %tip.amount,
+                    error = %e,
+                    "Reconciliation: cannot parse tip amount; skipping"
+                );
+                continue;
+            }
+        };
+
+        // Look up the creator's wallet address
+        let destination = match fetch_creator_wallet(&state, &tip.creator_username).await {
+            Ok(Some(addr)) => addr,
+            Ok(None) => {
+                tracing::warn!(
+                    tip_id = %tip.id,
+                    creator = %tip.creator_username,
+                    "Reconciliation: creator not found; skipping"
+                );
+                continue;
+            }
+            Err(e) => {
+                tracing::error!(
+                    tip_id = %tip.id,
+                    error = %e,
+                    "Reconciliation: failed to fetch creator wallet"
+                );
+                continue;
+            }
+        };
+
+        let job = VerificationJob {
+            tip_id: tip.id,
+            transaction_hash: tip.transaction_hash.clone(),
+            amount_stroops,
+            destination,
+            expected_memo: None,
+            source_account: tip
+                .tipper_source_account
+                .clone()
+                .unwrap_or_default(),
+            attempt: 0,
+        };
+
+        match state.queue.enqueue(job).await {
+            Ok(()) => {
+                tracing::info!(
+                    tip_id = %tip.id,
+                    "Reconciliation: re-enqueued stuck tip"
+                );
+                enqueued += 1;
+            }
+            Err(e) => {
+                tracing::error!(
+                    tip_id = %tip.id,
+                    error = %e,
+                    "Reconciliation: failed to enqueue tip"
+                );
+            }
+        }
+    }
+
+    tracing::info!("Reconciliation: re-enqueued {}/{} tips", enqueued, stuck_tips.len());
+    enqueued
+}
+
+async fn fetch_stuck_tips(state: &AppState) -> Result<Vec<StuckTip>, sqlx::Error> {
+    let stuck_threshold = chrono::Utc::now() - chrono::Duration::from_std(STUCK_AFTER).unwrap();
+
+    sqlx::query_as::<_, StuckTip>(
+        r#"
+        SELECT id, transaction_hash, amount, creator_username, tipper_source_account
+        FROM tips
+        WHERE status = 'pending_verification'
+          AND created_at < $1
+        ORDER BY created_at ASC
+        LIMIT 100
+        "#,
+    )
+    .bind(stuck_threshold)
+    .fetch_all(&state.db)
+    .await
+}
+
+async fn fetch_creator_wallet(
+    state: &AppState,
+    username: &str,
+) -> Result<Option<String>, sqlx::Error> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT wallet_address FROM creators WHERE username = $1",
+    )
+    .bind(username)
+    .fetch_optional(&state.db)
+    .await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@ pub fn create_app(state: Arc<AppState>) -> Router {
         .allow_origin(Any)
         .allow_headers(Any);
 
-    // Build rate limiters. They handle their own background cleanup.
     let general_limiter = middleware::rate_limiter::general_limiter();
     let write_limiter = middleware::rate_limiter::write_limiter();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
-use axum::Router;
+use axum::{http::Method, Router};
+use sqlx::postgres::PgPoolOptions;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::broadcast;
+use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
+use tokio::sync::broadcast;
 
 mod analytics;
 mod anonymization;
@@ -23,6 +25,8 @@ mod db;
 mod deduplication;
 mod deployment;
 mod docs;
+mod jobs;
+mod metrics;
 mod email;
 mod errors;
 mod events;
@@ -30,9 +34,7 @@ mod gateway;
 mod graphql;
 mod health;
 mod indexer;
-mod jobs;
 mod logging;
-mod metrics;
 mod middleware;
 mod ml;
 mod moderation;
@@ -63,6 +65,9 @@ use docs::ApiDoc;
 use graphql::schema::{graphql_handler, graphql_ws_handler};
 use service_mesh::discovery::ServiceRegistry;
 use services::stellar_service::StellarService;
+use crate::queue::VerificationQueue;
+use crate::queue::worker::spawn_worker;
+use crate::jobs::reconciliation;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -95,8 +100,8 @@ async fn main() -> anyhow::Result<()> {
 
     sqlx::migrate!("./migrations").run(&pool).await?;
 
-    // --- Services Initialization (Merged from Main) ---
-    let stellar = StellarService::new(stellar_rpc_url, stellar_network);
+    // ── Services ──────────────────────────────────────────────────────────────
+    let stellar = Arc::new(StellarService::new(stellar_rpc_url, stellar_network));
     let performance = Arc::new(db::performance::PerformanceMonitor::new());
     let (broadcast_tx, _) = broadcast::channel(ws::CHANNEL_CAPACITY);
 
@@ -105,14 +110,13 @@ async fn main() -> anyhow::Result<()> {
         std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
     let redis = cache::redis_client::connect(&redis_url).await;
 
-    // Email Worker (Added from Main)
+    // Email worker
     let (email_sender, email_rx) = email::sender::EmailSender::new();
     tokio::spawn(email::sender::start_email_worker(email_rx));
-    let email_sender = Arc::new(email_sender);
+    let _email_sender = Arc::new(email_sender);
 
-    // Service Layer Orchestration (Added from Main)
-    let tip_service = Arc::new(services::tip_service::TipService::new());
-    let creator_service = Arc::new(services::creator_service::CreatorService::new());
+    // ── Verification Queue ────────────────────────────────────────────────────
+    let (queue, queue_rx) = VerificationQueue::new();
 
     let moderation = Arc::new(moderation::ModerationService::new(pool.clone()));
 
@@ -166,7 +170,8 @@ async fn main() -> anyhow::Result<()> {
 
     let state = Arc::new(AppState {
         db: pool.clone(),
-        stellar,
+        verifier: stellar,
+        queue,
         performance,
         redis,
         broadcast_tx,
@@ -244,6 +249,11 @@ async fn main() -> anyhow::Result<()> {
         audit: Arc::new(anonymization::audit::AnonymizationAudit::new(pool.clone())),
     });
 
+    // Spawn verification queue worker
+    spawn_worker(Arc::clone(&state), queue_rx);
+    // Reconciliation job: re-drives stuck pending_verification tips
+    reconciliation::spawn(Arc::clone(&state));
+
     // Start RabbitMQ queue system (optional — skipped when RABBITMQ_URL is unset).
     let queue_system = queue::try_start(Arc::clone(&state)).await;
 
@@ -318,7 +328,6 @@ async fn main() -> anyhow::Result<()> {
 
     let cors = middleware::cors::cors_layer();
 
-    // Build rate limiters (Your FIXED version - no tuples!)
     let general_limiter_v1 = middleware::rate_limiter::general_limiter();
     let write_limiter_v1 = middleware::rate_limiter::write_limiter();
     let general_limiter_v2 = middleware::rate_limiter::general_limiter();
@@ -469,8 +478,6 @@ async fn main() -> anyhow::Result<()> {
     .layer(quota_enforcement_layer_v2)
     .layer(gateway_rate_limit_layer_v2)
     .layer(gateway_auth_layer);
-
-    let x_request_id = axum::http::HeaderName::from_static("x-request-id");
 
     let gql_schema = graphql::schema::build_schema(Arc::clone(&state));
 

--- a/src/models/tip.rs
+++ b/src/models/tip.rs
@@ -44,6 +44,75 @@ impl std::fmt::Display for MessageVisibility {
     }
 }
 
+// ─────────────────────────── TipStatus ──────────────────────────────────────
+
+/// Two-phase tip state for on-chain settlement verification.
+///
+/// State machine: `pending_verification` → `confirmed` | `rejected`
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TipStatus {
+    PendingVerification,
+    Confirmed,
+    Rejected,
+}
+
+impl TipStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::PendingVerification => "pending_verification",
+            Self::Confirmed => "confirmed",
+            Self::Rejected => "rejected",
+        }
+    }
+}
+
+impl std::fmt::Display for TipStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for TipStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending_verification" => Ok(Self::PendingVerification),
+            "confirmed" => Ok(Self::Confirmed),
+            "rejected" => Ok(Self::Rejected),
+            other => Err(format!("unknown tip status: {}", other)),
+        }
+    }
+}
+
+// sqlx encode/decode so the column maps cleanly
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for TipStatus {
+    fn decode(
+        value: sqlx::postgres::PgValueRef<'r>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let s = <&str as sqlx::Decode<'r, sqlx::Postgres>>::decode(value)?;
+        s.parse::<TipStatus>().map_err(|e| e.into())
+    }
+}
+
+impl sqlx::Type<sqlx::Postgres> for TipStatus {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <&str as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+}
+
+impl sqlx::Encode<'_, sqlx::Postgres> for TipStatus {
+    fn encode_by_ref(
+        &self,
+        buf: &mut sqlx::postgres::PgArgumentBuffer,
+    ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Send + Sync>> {
+        <&str as sqlx::Encode<sqlx::Postgres>>::encode_by_ref(&self.as_str(), buf)
+    }
+}
+
+// ─────────────────────────── Tip entity ─────────────────────────────────────
+
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Tip {
     pub id: Uuid,
@@ -53,7 +122,26 @@ pub struct Tip {
     pub message: Option<String>,
     pub message_visibility: Option<String>,
     pub created_at: DateTime<Utc>,
+    /// Verification state; defaults to `confirmed` for legacy rows.
+    #[sqlx(default)]
+    pub status: Option<TipStatus>,
+    /// The Stellar source account that submitted the tip transaction.
+    #[sqlx(default)]
+    pub tipper_source_account: Option<String>,
 }
+
+impl Tip {
+    /// Return the effective status, treating NULL (legacy rows) as confirmed.
+    pub fn effective_status(&self) -> TipStatus {
+        self.status.clone().unwrap_or(TipStatus::Confirmed)
+    }
+
+    pub fn is_confirmed(&self) -> bool {
+        self.effective_status() == TipStatus::Confirmed
+    }
+}
+
+// ─────────────────────────── Request DTOs ───────────────────────────────────
 
 /// Request body for recording a tip
 #[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
@@ -87,6 +175,13 @@ pub struct RecordTipRequest {
     /// Visibility of the message: "public" (default), "private"
     #[serde(default)]
     pub message_visibility: MessageVisibility,
+
+    /// The tipper's Stellar account address (source account of the transaction)
+    #[validate(length(min = 56, max = 56, message = "Stellar address must be 56 characters"))]
+    pub tipper_source_account: String,
+
+    /// Optional memo included in the Stellar transaction
+    pub memo: Option<String>,
 }
 
 fn validate_tx_hash(hash: &str) -> Result<(), validator::ValidationError> {
@@ -154,7 +249,9 @@ impl TipSortParams {
     }
 }
 
-/// Tip record response
+// ─────────────────────────── Response DTOs ──────────────────────────────────
+
+/// Tip record response – only exposes confirmed tips in the public API.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct TipResponse {
     pub id: Uuid,
@@ -164,6 +261,7 @@ pub struct TipResponse {
     pub message: Option<String>,
     pub message_visibility: String,
     pub created_at: DateTime<Utc>,
+    pub status: String,
 }
 
 impl From<Tip> for TipResponse {
@@ -176,6 +274,7 @@ impl From<Tip> for TipResponse {
             message: t.message,
             message_visibility: t.message_visibility.unwrap_or_else(|| "public".to_string()),
             created_at: t.created_at,
+            status: t.effective_status().to_string(),
         }
     }
 }

--- a/src/queue/mod.rs
+++ b/src/queue/mod.rs
@@ -3,6 +3,7 @@ pub mod consumer;
 pub mod handlers;
 pub mod publisher;
 pub mod system;
+pub mod worker;
 
 // Flat re-exports for the most commonly used types.
 pub use connection::RabbitMQConnection;
@@ -12,3 +13,69 @@ pub use handlers::{
 };
 pub use publisher::{DeadLetterMessage, Message, MessagePublisher};
 pub use system::{try_start, QueueSystem};
+
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+/// A verification job payload queued for async processing.
+#[derive(Debug, Clone)]
+pub struct VerificationJob {
+    /// The tip's database ID.
+    pub tip_id: Uuid,
+    /// The Stellar transaction hash to verify.
+    pub transaction_hash: String,
+    /// Claimed amount in stroops.
+    pub amount_stroops: i64,
+    /// Creator's Stellar wallet address (payment destination).
+    pub destination: String,
+    /// Optional memo the tipper should have included.
+    pub expected_memo: Option<String>,
+    /// Claimed source (tipper's Stellar account).
+    pub source_account: String,
+    /// How many times this job has been attempted.
+    pub attempt: u32,
+}
+
+/// A cloneable sender handle for enqueuing verification jobs.
+#[derive(Clone)]
+pub struct VerificationQueue {
+    sender: mpsc::Sender<VerificationJob>,
+}
+
+impl VerificationQueue {
+    /// Maximum number of jobs that can wait in the channel before back-pressure.
+    const CHANNEL_CAPACITY: usize = 1_024;
+
+    /// Create a new queue and return the sender half plus the receiver for the worker.
+    pub fn new() -> (Self, mpsc::Receiver<VerificationJob>) {
+        let (sender, receiver) = mpsc::channel(Self::CHANNEL_CAPACITY);
+        (Self { sender }, receiver)
+    }
+
+    /// Enqueue a job for background verification.
+    ///
+    /// Returns `Ok(())` if the job was accepted; `Err` if the channel is full
+    /// or closed, which callers should treat as a best-effort degradation path
+    /// (the reconciliation job will pick it up later).
+    pub async fn enqueue(&self, job: VerificationJob) -> Result<(), String> {
+        self.sender
+            .send(job)
+            .await
+            .map_err(|e| format!("Verification queue full or closed: {}", e))
+    }
+
+    /// Try to enqueue without waiting. Returns immediately if channel is full.
+    pub fn try_enqueue(&self, job: VerificationJob) -> Result<(), String> {
+        self.sender
+            .try_send(job)
+            .map_err(|e| format!("Verification queue try_send failed: {}", e))
+    }
+}
+
+// Allow constructing a VerificationQueue in tests easily
+impl std::fmt::Debug for VerificationQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VerificationQueue").finish()
+    }
+}

--- a/src/queue/worker.rs
+++ b/src/queue/worker.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+use crate::db::connection::AppState;
+use crate::services::stellar_service::{TipVerifyRequest, VerifyOutcome};
+use super::VerificationJob;
+
+/// Maximum attempts before a job is abandoned (tip left as pending for reconciliation).
+const MAX_ATTEMPTS: u32 = 5;
+
+/// Spawn a background task that drains the verification job queue and
+/// drives `pending_verification` tips to `confirmed` or `rejected`.
+pub fn spawn_worker(
+    state: Arc<AppState>,
+    mut receiver: mpsc::Receiver<VerificationJob>,
+) {
+    tokio::spawn(async move {
+        tracing::info!("Verification queue worker started");
+
+        while let Some(job) = receiver.recv().await {
+            let state_clone = Arc::clone(&state);
+            tokio::spawn(async move {
+                process_job(state_clone, job).await;
+            });
+        }
+
+        tracing::warn!("Verification queue channel closed – worker exiting");
+    });
+}
+
+async fn process_job(state: Arc<AppState>, job: VerificationJob) {
+    let tip_id = job.tip_id;
+    let attempt = job.attempt;
+
+    tracing::info!(
+        tip_id = %tip_id,
+        tx_hash = %job.transaction_hash,
+        attempt = attempt,
+        "Processing verification job"
+    );
+
+    if attempt >= MAX_ATTEMPTS {
+        tracing::error!(
+            tip_id = %tip_id,
+            "Max verification attempts reached – leaving tip in pending_verification for reconciliation"
+        );
+        return;
+    }
+
+    let verify_req = TipVerifyRequest {
+        transaction_hash: job.transaction_hash.clone(),
+        amount_stroops: job.amount_stroops,
+        destination: job.destination.clone(),
+        expected_memo: job.expected_memo.clone(),
+        source_account: job.source_account.clone(),
+    };
+
+    match state.verifier.verify_tip(&verify_req).await {
+        Ok(VerifyOutcome::Confirmed) => {
+            tracing::info!(tip_id = %tip_id, "Tip confirmed by on-chain verification");
+            if let Err(e) = crate::controllers::tip_controller::confirm_tip(&state, tip_id).await {
+                tracing::error!(tip_id = %tip_id, error = %e, "Failed to confirm tip in database");
+            }
+        }
+        Ok(VerifyOutcome::Rejected { reason }) => {
+            tracing::warn!(tip_id = %tip_id, reason = %reason, "Tip rejected by on-chain verification");
+            if let Err(e) = crate::controllers::tip_controller::reject_tip(&state, tip_id, &reason).await {
+                tracing::error!(tip_id = %tip_id, error = %e, "Failed to reject tip in database");
+            }
+        }
+        Err(e) => {
+            // Transient error (network, circuit breaker) – re-enqueue with backoff
+            tracing::warn!(
+                tip_id = %tip_id,
+                error = %e,
+                attempt = attempt,
+                "Verification failed transiently; re-enqueueing"
+            );
+
+            let backoff = Duration::from_secs(2u64.saturating_pow(attempt + 1).min(64));
+            tokio::time::sleep(backoff).await;
+
+            let retry_job = VerificationJob {
+                attempt: attempt + 1,
+                ..job
+            };
+
+            if let Err(send_err) = state.queue.enqueue(retry_job).await {
+                tracing::error!(
+                    tip_id = %tip_id,
+                    error = %send_err,
+                    "Failed to re-enqueue job; reconciliation will retry"
+                );
+            }
+        }
+    }
+}

--- a/src/routes/creators.rs
+++ b/src/routes/creators.rs
@@ -17,6 +17,7 @@ use crate::models::creator::{
 use crate::models::pagination::PaginationParams;
 use crate::models::tip::{TipFilters, TipResponse, TipSortParams};
 use crate::search::SearchQuery;
+use crate::validation::ValidatedJson;
 
 /// Write routes: POST /creators — subject to stricter rate limiting.
 pub fn write_router() -> Router<Arc<AppState>> {
@@ -34,7 +35,6 @@ pub fn read_router() -> Router<Arc<AppState>> {
         .route("/creators/:username/tips", get(get_creator_tips))
 }
 
-/// Create a new creator profile
 #[utoipa::path(
     post,
     path = "/creators",
@@ -48,21 +48,18 @@ pub fn read_router() -> Router<Arc<AppState>> {
 )]
 pub async fn create_creator(
     State(state): State<Arc<AppState>>,
-    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<CreateCreatorRequest>,
+    ValidatedJson(body): ValidatedJson<CreateCreatorRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let creator = creator_controller::create_creator(&state, body).await?;
     let response: CreatorResponse = creator.into();
-    Ok((StatusCode::CREATED, Json(serde_json::json!(response))).into_response())
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
-/// Get a creator by username
 #[utoipa::path(
     get,
     path = "/creators/{username}",
     tag = "creators",
-    params(
-        ("username" = String, Path, description = "Creator's unique username")
-    ),
+    params(("username" = String, Path, description = "Creator username")),
     responses(
         (status = 200, description = "Creator found", body = CreatorResponse),
         (status = 404, description = "Creator not found"),
@@ -75,20 +72,19 @@ pub async fn get_creator(
 ) -> Result<impl IntoResponse, AppError> {
     let creator = creator_controller::get_creator_or_not_found(&state, &username).await?;
     let response: CreatorResponse = creator.into();
-    Ok((StatusCode::OK, Json(serde_json::json!(response))).into_response())
+    Ok((StatusCode::OK, Json(response)))
 }
 
-/// List tips for a creator with pagination
 #[utoipa::path(
     get,
     path = "/creators/{username}/tips",
     tag = "creators",
     params(
-        ("username" = String, Path, description = "Creator's unique username"),
+        ("username" = String, Path, description = "Creator username"),
         PaginationParams,
     ),
     responses(
-        (status = 200, description = "Paginated list of tips"),
+        (status = 200, description = "Confirmed tips for creator"),
         (status = 500, description = "Internal server error")
     )
 )]
@@ -111,7 +107,7 @@ pub async fn get_creator_tips(
             HeaderValue::from_static("Offset pagination is deprecated; use signed keyset cursors."),
         );
     }
-    Ok((headers, StatusCode::OK, Json(serde_json::json!(response))).into_response())
+    Ok((headers, axum::http::StatusCode::OK, Json(serde_json::json!(response))).into_response())
 }
 
 /// Update a creator's wallet address with proof of ownership from the new address.
@@ -171,14 +167,13 @@ pub async fn update_creator_profile(
     Ok((StatusCode::OK, Json(serde_json::json!(response))).into_response())
 }
 
-/// Search creators by username
 #[utoipa::path(
     get,
     path = "/creators/search",
     tag = "creators",
     params(SearchQuery),
     responses(
-        (status = 200, description = "Search results", body = Vec<CreatorResponse>),
+        (status = 200, description = "Search results"),
         (status = 400, description = "Missing or invalid query parameter"),
         (status = 500, description = "Internal server error")
     )
@@ -192,8 +187,7 @@ pub async fn search_creators(
             message: "Query parameter 'q' must not be empty".to_string(),
         }));
     }
-
-    match creator_controller::search_creators(&state, &query).await {
+    match creator_controller::search_creators(&state.db, &query).await {
         Ok(creators) => {
             let response: Vec<CreatorResponse> = creators.into_iter().map(Into::into).collect();
             Ok((StatusCode::OK, Json(serde_json::json!(response))).into_response())

--- a/src/routes/tips.rs
+++ b/src/routes/tips.rs
@@ -10,12 +10,12 @@ use uuid::Uuid;
 
 use crate::controllers::tip_controller;
 use crate::db::connection::AppState;
-use crate::errors::{AppError, StellarError};
+use crate::errors::AppError;
 use crate::models::pagination::PaginationParams;
 use crate::models::tip::{
     RecordTipRequest, ReportMessageRequest, TipFilters, TipResponse, TipSortParams,
 };
-use crate::services::validation_service::{TipValidationService, ValidationRules};
+use crate::validation::ValidatedJson;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -23,14 +23,22 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/tips/:id/report", post(report_tip_message))
 }
 
-/// Record a new tip (verifies transaction on the Stellar network first)
+/// Submit a tip for async on-chain verification.
+///
+/// The tip is stored immediately as `pending_verification`. The background
+/// worker verifies the Stellar transaction and transitions the tip to
+/// `confirmed` or `rejected`. Webhooks and leaderboard updates only fire
+/// once the tip reaches `confirmed`.
 #[utoipa::path(
     post,
     path = "/tips",
     tag = "tips",
     request_body = RecordTipRequest,
     responses(
-        (status = 201, description = "Tip recorded successfully", body = TipResponse),
+        (status = 201, description = "Tip accepted for verification", body = TipResponse),
+        (status = 400, description = "Invalid request body or validation failure"),
+        (status = 404, description = "Creator not found"),
+        (status = 409, description = "Duplicate transaction hash"),
         (status = 422, description = "Transaction not found or unsuccessful on Stellar network"),
         (status = 502, description = "Unable to reach Stellar network for verification"),
         (status = 500, description = "Internal server error")
@@ -38,37 +46,11 @@ pub fn router() -> Router<Arc<AppState>> {
 )]
 pub async fn record_tip(
     State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
-    crate::validation::ValidatedJson(body): crate::validation::ValidatedJson<RecordTipRequest>,
+    ValidatedJson(body): ValidatedJson<RecordTipRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let client_ip = extract_client_ip(&headers);
-    let validator = TipValidationService::new(ValidationRules::default());
-    validator
-        .validate_with_client(&state.db, &body, client_ip)
-        .await?;
-
-    match state
-        .stellar
-        .verify_transaction(&body.transaction_hash)
-        .await
-    {
-        Ok(false) => {
-            return Err(AppError::Stellar(StellarError::TransactionNotFound {
-                hash: body.transaction_hash.clone(),
-            }));
-        }
-        Err(e) => return Err(e),
-        Ok(true) => {}
-    }
-
-    let tip = tip_controller::record_tip_with_context(
-        &state,
-        body,
-        tip_controller::TipRecordContext { ip: client_ip },
-    )
-    .await?;
+    let tip = tip_controller::record_tip(&state, body).await?;
     let response: TipResponse = tip.into();
-    Ok((StatusCode::CREATED, Json(serde_json::json!(response))).into_response())
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// List all tips with pagination, filtering, and sorting
@@ -99,7 +81,7 @@ pub async fn list_tips(
             HeaderValue::from_static("Offset pagination is deprecated; use signed keyset cursors."),
         );
     }
-    Ok((headers, StatusCode::OK, Json(serde_json::json!(response))).into_response())
+    Ok((headers, axum::http::StatusCode::OK, Json(serde_json::json!(response))).into_response())
 }
 
 /// Report a tip message for moderation review

--- a/src/saga/tip_saga.rs
+++ b/src/saga/tip_saga.rs
@@ -9,25 +9,8 @@ use crate::models::tip::RecordTipRequest;
 
 /// Context keys used between steps.
 const KEY_TIP_ID: &str = "tip_id";
-const KEY_TX_HASH: &str = "transaction_hash";
 
-// ── Step 1: verify the Stellar transaction ────────────────────────────────────
-
-struct VerifyTransactionStep {
-    state: Arc<AppState>,
-    tx_hash: String,
-}
-
-#[async_trait::async_trait]
-impl SagaAction for VerifyTransactionStep {
-    async fn execute(&self, ctx: &mut SagaContext) -> AppResult<()> {
-        self.state.stellar.verify_transaction(&self.tx_hash).await?;
-        ctx.set(KEY_TX_HASH, &self.tx_hash);
-        Ok(())
-    }
-}
-
-// ── Step 2: record the tip in the database ────────────────────────────────────
+// ── Step 1: record the tip in the database (as pending_verification) ──────────
 
 struct RecordTipStep {
     state: Arc<AppState>,
@@ -44,6 +27,8 @@ impl SagaAction for RecordTipStep {
                 amount: self.req.amount.clone(),
                 tipper_wallet: self.req.tipper_wallet.clone(),
                 transaction_hash: self.req.transaction_hash.clone(),
+                tipper_source_account: self.req.tipper_source_account.clone(),
+                memo: self.req.memo.clone(),
                 message: self.req.message.clone(),
                 message_visibility: self.req.message_visibility.clone(),
             },
@@ -71,7 +56,7 @@ impl CompensationAction for DeleteTipCompensation {
     }
 }
 
-// ── Step 3: fire webhook notification ─────────────────────────────────────────
+// ── Step 2: fire webhook notification (only fires for confirmed tips) ─────────
 
 struct NotifyStep {
     state: Arc<AppState>,
@@ -87,8 +72,11 @@ impl SagaAction for NotifyStep {
             "tip_id": tip_id,
             "creator_username": self.username,
             "amount": self.amount,
+            "status": "pending_verification",
         });
-        crate::webhooks::trigger_webhooks(self.state.db.clone(), "tip.recorded", payload).await;
+        // Note: "tip.submitted" event – does NOT trigger leaderboard/stats.
+        // "tip.confirmed" is emitted by confirm_tip() after on-chain verification.
+        crate::webhooks::trigger_webhooks(self.state.db.clone(), "tip.submitted", payload).await;
         Ok(())
     }
 }
@@ -103,16 +91,6 @@ pub async fn run_tip_saga(state: Arc<AppState>, req: RecordTipRequest) -> AppRes
 
     let steps: Vec<SagaStep> = vec![
         SagaStep {
-            name: "verify_transaction",
-            action: Box::new(VerifyTransactionStep {
-                state: Arc::clone(&state),
-                tx_hash: req.transaction_hash.clone(),
-            }),
-            compensation: Box::new(NoOpCompensation),
-            max_retries: 2,
-            retry_backoff_ms: 200,
-        },
-        SagaStep {
             name: "record_tip",
             action: Box::new(RecordTipStep {
                 state: Arc::clone(&state),
@@ -121,6 +99,8 @@ pub async fn run_tip_saga(state: Arc<AppState>, req: RecordTipRequest) -> AppRes
                     amount: req.amount.clone(),
                     tipper_wallet: req.tipper_wallet.clone(),
                     transaction_hash: req.transaction_hash.clone(),
+                    tipper_source_account: req.tipper_source_account.clone(),
+                    memo: req.memo.clone(),
                     message: req.message.clone(),
                     message_visibility: req.message_visibility.clone(),
                 },

--- a/src/services/stellar_service.rs
+++ b/src/services/stellar_service.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -7,13 +8,87 @@ use super::circuit_breaker::CircuitBreaker;
 use super::retry::{with_retry, RetryConfig};
 use crate::errors::{AppError, AppResult, StellarError};
 
+// ─────────────────────────── Horizon Response Types ─────────────────────────
+
+/// Full Horizon transaction response with all fields needed for tip verification.
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct HorizonTransactionResponse {
     pub id: String,
     pub hash: String,
     pub successful: bool,
+    /// The Stellar account that submitted (signed) the transaction.
+    pub source_account: String,
+    /// Base64-encoded XDR memo value; may be absent.
+    #[serde(default)]
+    pub memo: Option<String>,
+    /// Memo type: "none", "text", "id", "hash", "return"
+    #[serde(default)]
+    pub memo_type: Option<String>,
 }
+
+/// A single operation embedded in a transaction (from the Horizon operations endpoint).
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct HorizonOperation {
+    #[serde(rename = "type")]
+    pub op_type: String,
+    /// Payment destination, if this is a payment operation.
+    #[serde(default)]
+    pub to: Option<String>,
+    /// Amount as a string (e.g. "10.5000000"), if present.
+    #[serde(default)]
+    pub amount: Option<String>,
+    /// Asset type: "native" for XLM.
+    #[serde(default)]
+    pub asset_type: Option<String>,
+}
+
+/// Horizon paginated response wrapper for operations.
+#[derive(Debug, Deserialize)]
+pub struct HorizonOperationsPage {
+    #[serde(rename = "_embedded")]
+    pub embedded: HorizonOperationsEmbedded,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HorizonOperationsEmbedded {
+    pub records: Vec<HorizonOperation>,
+}
+
+// ─────────────────────────── TipVerifier Trait ──────────────────────────────
+
+/// All the fields the verifier must check to approve a tip.
+#[derive(Debug, Clone)]
+pub struct TipVerifyRequest {
+    /// The Stellar transaction hash to look up.
+    pub transaction_hash: String,
+    /// Claimed payment amount in stroops (1 XLM = 10,000,000 stroops).
+    /// Must be compared as integers – no floating-point arithmetic.
+    pub amount_stroops: i64,
+    /// Creator's Stellar wallet address (payment destination).
+    pub destination: String,
+    /// Optional memo that the tipper was supposed to include.
+    pub expected_memo: Option<String>,
+    /// Claimed source account (tipper's Stellar address).
+    pub source_account: String,
+}
+
+/// The outcome of tip verification.
+#[derive(Debug, Clone, PartialEq)]
+pub enum VerifyOutcome {
+    Confirmed,
+    Rejected { reason: String },
+}
+
+/// Injectable verifier abstraction.  
+/// Production code uses `StellarService`; tests inject `MockTipVerifier`.
+#[async_trait]
+pub trait TipVerifier: Send + Sync + 'static {
+    async fn verify_tip(&self, req: &TipVerifyRequest) -> AppResult<VerifyOutcome>;
+}
+
+// ─────────────────────────── StellarService ─────────────────────────────────
 
 #[allow(dead_code)]
 #[derive(Debug, Serialize)]
@@ -37,7 +112,10 @@ pub struct StellarService {
 impl StellarService {
     pub fn new(rpc_url: String, network: String) -> Self {
         Self {
-            client: Client::new(),
+            client: Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .expect("failed to build reqwest client"),
             rpc_url,
             network,
             retry_config: RetryConfig::default(),
@@ -45,26 +123,25 @@ impl StellarService {
         }
     }
 
-    /// Verify that a transaction exists and was successful on the Stellar network.
-    ///
-    /// Uses retry with exponential backoff for transient network errors and a
-    /// circuit breaker to avoid hammering a failing Horizon server.
-    pub async fn verify_transaction(&self, transaction_hash: &str) -> AppResult<bool> {
-        if !self.circuit_breaker.allow_request() {
-            tracing::warn!(
-                "Circuit breaker open; skipping verification for {}",
-                transaction_hash
-            );
-            return Err(AppError::Stellar(StellarError::CircuitBreakerOpen));
-        }
-
-        let horizon_base = if self.network == "mainnet" {
+    fn horizon_base(&self) -> &'static str {
+        if self.network == "mainnet" {
             "https://horizon.stellar.org"
         } else {
             "https://horizon-testnet.stellar.org"
-        };
+        }
+    }
 
-        let url = format!("{}/transactions/{}", horizon_base, transaction_hash);
+    /// Low-level: fetch a transaction record from Horizon with retry + circuit-breaker.
+    async fn fetch_transaction(
+        &self,
+        hash: &str,
+    ) -> AppResult<Option<HorizonTransactionResponse>> {
+        if !self.circuit_breaker.allow_request() {
+            tracing::warn!("Circuit breaker open; skipping Horizon call for {}", hash);
+            return Err(AppError::Stellar(StellarError::CircuitBreakerOpen));
+        }
+
+        let url = format!("{}/transactions/{}", self.horizon_base(), hash);
         let client = self.client.clone();
         let cb = self.circuit_breaker.clone();
 
@@ -78,17 +155,22 @@ impl StellarService {
                     .await
                     .map_err(|_| AppError::Stellar(StellarError::NetworkUnavailable))?;
 
-                if resp.status().is_success() {
-                    let tx: HorizonTransactionResponse = resp.json().await.map_err(|_| {
-                        AppError::Stellar(StellarError::InvalidTransaction {
-                            reason: "Malformed Horizon response".to_string(),
-                        })
-                    })?;
-                    Ok(tx.successful)
-                } else if resp.status().as_u16() == 404 {
-                    Ok(false)
-                } else {
-                    Err(AppError::Stellar(StellarError::NetworkUnavailable))
+                match resp.status().as_u16() {
+                    200 => {
+                        let tx: HorizonTransactionResponse = resp.json().await.map_err(|_| {
+                            AppError::Stellar(StellarError::InvalidTransaction {
+                                reason: "Malformed Horizon response".to_string(),
+                            })
+                        })?;
+                        Ok(Some(tx))
+                    }
+                    404 => Ok(None),
+                    429 | 500..=599 => {
+                        Err(AppError::Stellar(StellarError::NetworkUnavailable))
+                    }
+                    other => Err(AppError::Stellar(StellarError::InvalidTransaction {
+                        reason: format!("Unexpected Horizon status: {}", other),
+                    })),
                 }
             }
         })
@@ -100,6 +182,69 @@ impl StellarService {
         }
 
         result
+    }
+
+    /// Fetch the list of operations for a transaction from Horizon.
+    async fn fetch_operations(
+        &self,
+        hash: &str,
+    ) -> AppResult<Vec<HorizonOperation>> {
+        let url = format!("{}/transactions/{}/operations", self.horizon_base(), hash);
+        let client = self.client.clone();
+
+        let result = with_retry(&self.retry_config, || {
+            let client = client.clone();
+            let url = url.clone();
+            async move {
+                let resp = client
+                    .get(&url)
+                    .send()
+                    .await
+                    .map_err(|_| AppError::Stellar(StellarError::NetworkUnavailable))?;
+
+                if resp.status().is_success() {
+                    let page: HorizonOperationsPage = resp.json().await.map_err(|_| {
+                        AppError::Stellar(StellarError::InvalidTransaction {
+                            reason: "Malformed Horizon operations response".to_string(),
+                        })
+                    })?;
+                    Ok(page.embedded.records)
+                } else {
+                    Err(AppError::Stellar(StellarError::NetworkUnavailable))
+                }
+            }
+        })
+        .await;
+
+        result
+    }
+
+    /// Legacy helper kept for backward compatibility – returns true if transaction
+    /// exists and is successful. Does not verify amounts or destinations.
+    pub async fn verify_transaction(&self, transaction_hash: &str) -> AppResult<bool> {
+        let tx = self.fetch_transaction(transaction_hash).await?;
+        Ok(tx.map(|t| t.successful).unwrap_or(false))
+    }
+
+    /// Convert XLM amount string (e.g. "10.5000000") to stroops (integer).
+    /// Horizon always returns 7 decimal places.
+    pub fn xlm_to_stroops(amount_str: &str) -> AppResult<i64> {
+        // Parse as a decimal with exactly 7 decimal places.
+        let parts: Vec<&str> = amount_str.split('.').collect();
+        let whole: i64 = parts[0].parse().map_err(|_| {
+            AppError::Stellar(StellarError::InvalidTransaction {
+                reason: format!("Could not parse amount whole part: {}", amount_str),
+            })
+        })?;
+        let fractional_str = parts.get(1).copied().unwrap_or("0");
+        // Pad or truncate to exactly 7 digits
+        let padded = format!("{:0<7}", fractional_str);
+        let fractional: i64 = padded[..7].parse().map_err(|_| {
+            AppError::Stellar(StellarError::InvalidTransaction {
+                reason: format!("Could not parse amount fractional part: {}", amount_str),
+            })
+        })?;
+        Ok(whole * 10_000_000 + fractional)
     }
 
     /// Get the current health of the Stellar network connection.
@@ -124,5 +269,93 @@ impl StellarService {
             .map_err(|_| AppError::Stellar(StellarError::NetworkUnavailable))?;
 
         Ok(response)
+    }
+}
+
+// ────────────────── TipVerifier implementation for StellarService ────────────
+
+#[async_trait]
+impl TipVerifier for StellarService {
+    /// Full on-chain verification:
+    /// 1. Transaction exists and succeeded.
+    /// 2. Source account matches claimed tipper.
+    /// 3. A payment operation exists with:
+    ///    - asset_type = "native" (XLM)
+    ///    - destination = creator wallet
+    ///    - amount (in stroops) == claimed amount (integer comparison)
+    /// 4. Memo matches expected_memo if provided.
+    async fn verify_tip(&self, req: &TipVerifyRequest) -> AppResult<VerifyOutcome> {
+        // ── Step 1: Fetch transaction ──────────────────────────────────────
+        let tx = match self.fetch_transaction(&req.transaction_hash).await? {
+            None => {
+                return Ok(VerifyOutcome::Rejected {
+                    reason: "Transaction not found on Stellar network".to_string(),
+                });
+            }
+            Some(tx) => tx,
+        };
+
+        if !tx.successful {
+            return Ok(VerifyOutcome::Rejected {
+                reason: "Transaction did not succeed on the Stellar network".to_string(),
+            });
+        }
+
+        // ── Step 2: Source account ─────────────────────────────────────────
+        if tx.source_account != req.source_account {
+            return Ok(VerifyOutcome::Rejected {
+                reason: format!(
+                    "Source account mismatch: expected {}, got {}",
+                    req.source_account, tx.source_account
+                ),
+            });
+        }
+
+        // ── Step 3: Memo ───────────────────────────────────────────────────
+        if let Some(expected) = &req.expected_memo {
+            let actual = tx.memo.as_deref().unwrap_or("");
+            if actual != expected.as_str() {
+                return Ok(VerifyOutcome::Rejected {
+                    reason: format!(
+                        "Memo mismatch: expected '{}', got '{}'",
+                        expected, actual
+                    ),
+                });
+            }
+        }
+
+        // ── Step 4: Operations ─────────────────────────────────────────────
+        let operations = self.fetch_operations(&req.transaction_hash).await?;
+
+        let matching_payment = operations.iter().find(|op| {
+            op.op_type == "payment"
+                && op.asset_type.as_deref() == Some("native")
+                && op.to.as_deref() == Some(req.destination.as_str())
+        });
+
+        match matching_payment {
+            None => Ok(VerifyOutcome::Rejected {
+                reason: format!(
+                    "No native payment to {} found in transaction",
+                    req.destination
+                ),
+            }),
+            Some(op) => {
+                // Amount comparison in stroops – no float arithmetic
+                let on_chain_amount_str = op.amount.as_deref().unwrap_or("0");
+                let on_chain_stroops = Self::xlm_to_stroops(on_chain_amount_str)?;
+
+                if on_chain_stroops != req.amount_stroops {
+                    Ok(VerifyOutcome::Rejected {
+                        reason: format!(
+                            "Amount mismatch: expected {} stroops, on-chain {}",
+                            req.amount_stroops, on_chain_stroops
+                        ),
+                    })
+                } else {
+                    Ok(VerifyOutcome::Confirmed)
+                }
+            }
+        }
     }
 }

--- a/src/services/tip_service.rs
+++ b/src/services/tip_service.rs
@@ -7,7 +7,6 @@ use crate::models::tip::{RecordTipRequest, Tip};
 use std::sync::Arc;
 
 /// Service for handling tip-related business logic and notifications.
-/// Abstracts the heavy lifting from the controllers.
 pub struct TipService;
 
 impl TipService {
@@ -15,7 +14,7 @@ impl TipService {
         Self
     }
 
-    /// Record a new tip and trigger a notification email to the creator receiver.
+    /// Record a new tip: persists as `pending_verification` and enqueues async verification.
     ///
     /// # Note on field naming
     /// Tracing fields use the exact struct field names from [`RecordTipRequest`]
@@ -30,12 +29,11 @@ impl TipService {
     )]
     pub async fn record_tip(&self, state: Arc<AppState>, req: RecordTipRequest) -> AppResult<Tip> {
         let tip = tip_controller::record_tip(&state, req).await?;
-
         tracing::info!(tip.id = %tip.id, "tip recorded successfully");
         Ok(tip)
     }
 
-    /// Retrieve all tips for a given creator username.
+    /// Retrieve all confirmed tips for a given creator username.
     #[tracing::instrument(
         name = "tip_service.get_tips_for_creator",
         skip(self, state),
@@ -64,44 +62,38 @@ impl TipService {
         state: &AppState,
         requests: Vec<RecordTipRequest>,
     ) -> AppResult<Vec<Tip>> {
-        let pool = state.db.clone();
-        with_db_retry(&pool, 3, |pool| {
-            let requests = requests.clone();
-            let state = state.clone();
-            Box::pin(async move {
-                with_transaction(pool, |tx| {
-                    Box::pin(async move {
-                        let mut results = Vec::new();
-                        for (i, req) in requests.into_iter().enumerate() {
-                            let sp = format!("tip_record_{}", i);
-                            crate::db::transaction::create_savepoint(tx, &sp)
-                                .await
-                                .map_err(AppError::from)?;
-                            match tip_controller::record_tip_in_tx(&state, tx, &req).await {
-                                Ok(tip) => {
-                                    results.push(tip);
-                                    crate::db::transaction::release_savepoint(tx, &sp)
-                                        .await
-                                        .map_err(AppError::from)?;
-                                }
-                                Err(e) => {
-                                    tracing::error!(
-                                        tip.index = i,
-                                        error = %e,
-                                        "bulk tip record failed; rolling back savepoint"
-                                    );
-                                    crate::db::transaction::rollback_savepoint(tx, &sp)
-                                        .await
-                                        .map_err(AppError::from)?;
-                                }
-                            }
-                        }
-                        Ok(results)
-                    })
-                })
+        let mut tx = crate::db::transaction::begin_transaction(&state.db)
+            .await
+            .map_err(AppError::from)?;
+        let mut results = Vec::new();
+
+        for (i, req) in requests.into_iter().enumerate() {
+            let sp = format!("tip_record_{}", i);
+            crate::db::transaction::create_savepoint(&mut tx, &sp)
                 .await
-            })
-        })
-        .await
+                .map_err(AppError::from)?;
+
+            match tip_controller::record_tip_in_tx(&mut tx, &req).await {
+                Ok(tip) => {
+                    results.push(tip);
+                    crate::db::transaction::release_savepoint(&mut tx, &sp)
+                        .await
+                        .map_err(AppError::from)?;
+                }
+                Err(e) => {
+                    tracing::error!(
+                        tip.index = i,
+                        error = %e,
+                        "bulk tip record failed; rolling back savepoint"
+                    );
+                    crate::db::transaction::rollback_savepoint(&mut tx, &sp)
+                        .await
+                        .map_err(AppError::from)?;
+                }
+            }
+        }
+
+        tx.commit().await?;
+        Ok(results)
     }
 }

--- a/src/validation/amount.rs
+++ b/src/validation/amount.rs
@@ -25,3 +25,69 @@ pub fn validate_xlm_amount(amount: &str) -> Result<(), ValidationError> {
 
     Ok(())
 }
+
+/// Convert an XLM amount string (e.g. "10.5" or "10.5000000") to stroops (i64).
+///
+/// This is an integer-only computation — no f64 used anywhere.
+///
+/// Stellar uses 7 decimal places: 1 XLM = 10_000_000 stroops.
+pub fn xlm_to_stroops_str(amount: &str) -> Result<i64, String> {
+    let amount = amount.trim();
+
+    // Split into whole and fractional parts.
+    let (whole_str, frac_str) = match amount.split_once('.') {
+        Some((w, f)) => (w, f),
+        None => (amount, ""),
+    };
+
+    // Validate
+    if whole_str.is_empty() {
+        return Err(format!("Invalid XLM amount: '{}'", amount));
+    }
+
+    let whole: i64 = whole_str
+        .parse()
+        .map_err(|_| format!("Cannot parse whole part '{}' of amount '{}'", whole_str, amount))?;
+
+    if whole < 0 {
+        return Err(format!("Amount must not be negative: '{}'", amount));
+    }
+
+    // Ensure at most 7 decimal digits; pad to exactly 7.
+    if frac_str.len() > 7 {
+        return Err(format!(
+            "Amount '{}' has more than 7 decimal places",
+            amount
+        ));
+    }
+
+    let padded = format!("{:0<7}", frac_str); // left-align, pad right with zeros
+    let fractional: i64 = padded[..7]
+        .parse()
+        .map_err(|_| format!("Cannot parse fractional part of amount '{}'", amount))?;
+
+    Ok(whole * 10_000_000 + fractional)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_xlm_to_stroops_exact() {
+        assert_eq!(xlm_to_stroops_str("10.0").unwrap(), 100_000_000);
+        assert_eq!(xlm_to_stroops_str("1.0000000").unwrap(), 10_000_000);
+        assert_eq!(xlm_to_stroops_str("0.0000001").unwrap(), 1);
+        assert_eq!(xlm_to_stroops_str("10.5").unwrap(), 105_000_000);
+    }
+
+    #[test]
+    fn test_xlm_to_stroops_no_fraction() {
+        assert_eq!(xlm_to_stroops_str("100").unwrap(), 1_000_000_000);
+    }
+
+    #[test]
+    fn test_xlm_to_stroops_too_many_decimals() {
+        assert!(xlm_to_stroops_str("1.12345678").is_err());
+    }
+}

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -4,11 +4,12 @@ use uuid::Uuid;
 pub async fn create_test_creator(pool: &PgPool, username: &str) -> Uuid {
     let id = Uuid::new_v4();
     sqlx::query(
-        "INSERT INTO creators (id, username, wallet_address, email, created_at) VALUES ($1, $2, $3, $4, NOW())"
+        "INSERT INTO creators (id, username, wallet_address, email, created_at) \
+         VALUES ($1, $2, $3, $4, NOW()) ON CONFLICT (username) DO NOTHING"
     )
     .bind(id)
     .bind(username)
-    .bind("GTEST_WALLET")
+    .bind("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
     .bind(format!("{}@example.com", username))
     .execute(pool)
     .await
@@ -16,15 +17,19 @@ pub async fn create_test_creator(pool: &PgPool, username: &str) -> Uuid {
     id
 }
 
+/// Insert a confirmed tip directly (bypasses verification pipeline).
 pub async fn create_test_tip(pool: &PgPool, username: &str, amount: &str) -> Uuid {
     let id = Uuid::new_v4();
     sqlx::query(
-        "INSERT INTO tips (id, creator_username, amount, transaction_hash, created_at) VALUES ($1, $2, $3, $4, NOW())"
+        "INSERT INTO tips \
+         (id, creator_username, amount, transaction_hash, tipper_source_account, status, created_at) \
+         VALUES ($1, $2, $3, $4, $5, 'confirmed', NOW())"
     )
     .bind(id)
     .bind(username)
     .bind(amount)
-    .bind(format!("TX_{}", Uuid::new_v4()))
+    .bind(format!("{:0>64}", Uuid::new_v4().simple()))
+    .bind("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN")
     .execute(pool)
     .await
     .unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,12 +1,59 @@
 pub mod fixtures;
+
+use async_trait::async_trait;
 use axum::Router;
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
+
 use stellar_tipjar_backend::db::connection::AppState;
+use stellar_tipjar_backend::errors::AppResult;
 use stellar_tipjar_backend::moderation::ModerationService;
-use stellar_tipjar_backend::services::stellar_service::StellarService;
+use stellar_tipjar_backend::queue::VerificationQueue;
+use stellar_tipjar_backend::services::stellar_service::{
+    StellarService, TipVerifier, TipVerifyRequest, VerifyOutcome,
+};
 use stellar_tipjar_backend::{cache, create_app, db, email};
+
+// ─────────────────────────── MockTipVerifier ────────────────────────────────
+
+/// Programmable mock that can be pre-loaded with expected outcomes.
+pub struct MockTipVerifier {
+    /// Ordered list of outcomes to return, consumed one by one.
+    outcomes: Mutex<Vec<AppResult<VerifyOutcome>>>,
+}
+
+impl MockTipVerifier {
+    /// Create a verifier that always returns `Confirmed`.
+    pub fn always_confirm() -> Arc<Self> {
+        Arc::new(Self {
+            outcomes: Mutex::new(vec![]),
+        })
+    }
+
+    /// Create a verifier pre-loaded with a sequence of outcomes.
+    pub fn with_outcomes(outcomes: Vec<AppResult<VerifyOutcome>>) -> Arc<Self> {
+        Arc::new(Self {
+            outcomes: Mutex::new(outcomes),
+        })
+    }
+}
+
+#[async_trait]
+impl TipVerifier for MockTipVerifier {
+    async fn verify_tip(&self, _req: &TipVerifyRequest) -> AppResult<VerifyOutcome> {
+        let mut queue = self.outcomes.lock().await;
+        if queue.is_empty() {
+            // Default: confirm unless instructed otherwise
+            Ok(VerifyOutcome::Confirmed)
+        } else {
+            queue.remove(0)
+        }
+    }
+}
+
+// ─────────────────────────── DB helpers ─────────────────────────────────────
 
 pub async fn setup_test_db() -> PgPool {
     dotenvy::from_filename(".env.test").ok();
@@ -39,66 +86,83 @@ pub async fn cleanup_test_db(pool: &PgPool) {
     .unwrap();
 }
 
-pub async fn create_test_app(pool: PgPool) -> (Router, String) {
-    let stellar_network = "testnet".to_string();
-    // In actual tests, you'd use httpmock for stellar_rpc_url
-    let stellar_rpc_url = "https://soroban-testnet.stellar.org".to_string();
+// ─────────────────────────── App factory ────────────────────────────────────
 
-    let stellar = StellarService::new(stellar_rpc_url, stellar_network);
+pub async fn create_test_app(pool: PgPool) -> (Router, String) {
+    create_test_app_with_verifier(pool, MockTipVerifier::always_confirm()).await
+}
+
+pub async fn create_test_app_with_verifier(
+    pool: PgPool,
+    verifier: Arc<dyn TipVerifier>,
+) -> (Router, String) {
     let performance = Arc::new(db::performance::PerformanceMonitor::new());
     let moderation = Arc::new(ModerationService::new(pool.clone()));
-
-    // Mock redis (or just let it fail/disable)
     let redis = None;
-
-    // Initialize email system
-    let (email_sender, _email_rx) = email::sender::EmailSender::new();
-    let email_sender = Arc::new(email_sender);
+    let (queue, _queue_rx) = VerificationQueue::new();
+    // Note: we intentionally drop queue_rx here so the channel is effectively
+    // a no-op in unit tests. The queue.enqueue() calls will succeed (channel not full),
+    // but nothing processes them, which is fine for handler-level tests.
 
     let state = Arc::new(AppState {
         db: pool,
-        stellar,
+        verifier,
+        queue,
         performance,
         moderation,
         redis,
         broadcast_tx: tokio::sync::broadcast::channel(16).0,
         cache: None,
         invalidator: None,
-        db_circuit_breaker: Arc::new(stellar_tipjar_backend::services::circuit_breaker::CircuitBreaker::new(5, std::time::Duration::from_secs(60))),
+        db_circuit_breaker: Arc::new(
+            stellar_tipjar_backend::services::circuit_breaker::CircuitBreaker::new(
+                5,
+                std::time::Duration::from_secs(60),
+            ),
+        ),
         lock_service: None,
     });
 
     (create_app(state), "mock_token".into())
 }
 
+/// Create a test app backed by a real StellarService pointing at a mock Horizon URL.
+/// Useful for tests that want to exercise the full HTTP Horizon path without hitting
+/// the live testnet.
 pub async fn create_test_app_with_mock_stellar(
     pool: PgPool,
     mock_stellar_url: &str,
 ) -> (Router, String) {
     let stellar_network = "testnet".to_string();
-
-    // Use the mock server URL for stellar service
-    let stellar = StellarService::new(mock_stellar_url.to_string(), stellar_network);
+    let stellar: Arc<dyn TipVerifier> = Arc::new(StellarService::new(
+        mock_stellar_url.to_string(),
+        stellar_network,
+    ));
     let performance = Arc::new(db::performance::PerformanceMonitor::new());
     let moderation = Arc::new(ModerationService::new(pool.clone()));
-
-    // Mock redis (or just let it fail/disable)
     let redis = None;
+    let (queue, _queue_rx) = VerificationQueue::new();
 
-    // Initialize email system
+    // Initialize email system (unused in tests but AppState may require it)
     let (email_sender, _email_rx) = email::sender::EmailSender::new();
-    let email_sender = Arc::new(email_sender);
+    let _email_sender = Arc::new(email_sender);
 
     let state = Arc::new(AppState {
         db: pool,
-        stellar,
+        verifier: stellar,
+        queue,
         performance,
         moderation,
         redis,
         broadcast_tx: tokio::sync::broadcast::channel(16).0,
         cache: None,
         invalidator: None,
-        db_circuit_breaker: Arc::new(stellar_tipjar_backend::services::circuit_breaker::CircuitBreaker::new(5, std::time::Duration::from_secs(60))),
+        db_circuit_breaker: Arc::new(
+            stellar_tipjar_backend::services::circuit_breaker::CircuitBreaker::new(
+                5,
+                std::time::Duration::from_secs(60),
+            ),
+        ),
         lock_service: None,
     });
 

--- a/tests/tips_test.rs
+++ b/tests/tips_test.rs
@@ -1,105 +1,479 @@
+/// Tip verification pipeline integration tests (issue #341).
+///
+/// Tests run against a real PostgreSQL test database (TEST_DATABASE_URL).
+/// Horizon calls are intercepted via the MockTipVerifier injected into AppState,
+/// so no network traffic occurs and the suite runs deterministically.
 use axum::http::StatusCode;
 use axum_test::TestServer;
 use httpmock::prelude::*;
-use serde_json::json;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::task::JoinSet;
 use uuid::Uuid;
+
 mod common;
 
-#[tokio::test]
-async fn test_record_tip_with_stellar_mock() {
-    let pool = common::setup_test_db().await;
-    let (app, _) = common::create_test_app(pool.clone()).await;
-    let server = TestServer::new(app).unwrap();
+use common::{cleanup_test_db, create_test_app, create_test_app_with_verifier, setup_test_db, MockTipVerifier};
+use stellar_tipjar_backend::controllers::tip_controller;
+use stellar_tipjar_backend::errors::AppError;
+use stellar_tipjar_backend::services::stellar_service::VerifyOutcome;
 
-    // Mock Stellar Horizon API
-    // Wait! Horizon URL is determined by stellar_network in services/stellar_service.rs.
-    // If stellar_network == "testnet", it uses https://horizon-testnet.stellar.org.
-    // To mock this, we'd need to change the base URL in StellarService.
-    // Actually, I'll just mock any request that matches.
-    // But since httpmock runs a server, we need the app to talk to it.
+// ──────────────────────────── helpers ────────────────────────────────────────
 
-    // Let's create a specialized test app for this!
-    let mock_server = MockServer::start();
-    let stellar_mock = mock_server.mock(|when, then| {
-        when.method(GET).path_contains("/transactions/TX123");
-        then.status(200).json_body(json!({
-            "id": "TX123",
-            "hash": "TX123",
-            "successful": true
-        }));
-    });
+const TX_HASH: &str = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+const TX_HASH2: &str = "1122334455667788990011223344556677889900112233445566778899001122";
+const TIPPER_ADDR: &str = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+const CREATOR_WALLET: &str = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
-    // We don't have an easy way to inject the mock URL into StellarService
-    // unless we create a specialized state.
-
-    // Given the task constraints, I'll focus on the DB part and the API response.
-
-    // Note: To truly mock this, we should have made StellarService constructor take the base URL.
-    // But let's assume for now the logic is correct.
-
-    // First create a creator to tip
-    server
+async fn create_creator(server: &TestServer, username: &str) {
+    let resp = server
         .post("/creators")
         .json(&json!({
-            "username": "tippee",
-            "wallet_address": "GHI789",
-            "email": "tippee@example.com"
+            "username": username,
+            "wallet_address": CREATOR_WALLET,
+            "email": format!("{}@test.com", username)
         }))
         .await;
-
-    // Then record a tip
-    // The stellar verification might fail if it tries to hit the real testnet or if the hash is invalid.
-    // For now I'll just check that it's reachable.
-
-    /*
-    let response = server
-        .post("/tips")
-        .json(&json!({
-            "username": "tippee",
-            "amount": "10.0",
-            "transaction_hash": "TX123"
-        }))
-        .await;
-    */
-
-    common::cleanup_test_db(&pool).await;
+    // 201 or 409 (already exists) are both acceptable in test setup
+    assert!(
+        resp.status_code() == StatusCode::CREATED || resp.status_code() == StatusCode::CONFLICT,
+        "create_creator failed with {}",
+        resp.status_code()
+    );
 }
 
+fn tip_body(username: &str, tx_hash: &str) -> Value {
+    json!({
+        "username": username,
+        "amount": "10.5",
+        "transaction_hash": tx_hash,
+        "tipper_source_account": TIPPER_ADDR,
+        "memo": null
+    })
+}
+
+// ──────────────────────────── tests ──────────────────────────────────────────
+
+/// Happy path: submit a valid tip → 201, status = pending_verification.
+/// Then drive confirmation via confirm_tip and verify the tip becomes confirmed.
 #[tokio::test]
-async fn test_get_tips_for_creator() {
-    let pool = common::setup_test_db().await;
-    let (app, _) = common::create_test_app(pool.clone()).await;
+async fn test_happy_path_tip_submitted_as_pending() {
+    let pool = setup_test_db().await;
+    let (app, _) = create_test_app(pool.clone()).await;
     let server = TestServer::new(app).unwrap();
 
-    // Create creator
-    server
-        .post("/creators")
+    create_creator(&server, "happy_creator").await;
+
+    let resp = server.post("/tips").json(&tip_body("happy_creator", TX_HASH)).await;
+    resp.assert_status(StatusCode::CREATED);
+
+    let body: Value = resp.json();
+    assert_eq!(body["status"], "pending_verification", "Tip should enter as pending_verification");
+    assert_eq!(body["creator_username"], "happy_creator");
+    assert_eq!(body["amount"], "10.5");
+
+    // The tip should NOT appear in the public tips list yet (gated on confirmed)
+    let list_resp = server.get("/creators/happy_creator/tips").await;
+    list_resp.assert_status(StatusCode::OK);
+    let tips: Vec<Value> = list_resp.json();
+    assert!(tips.is_empty(), "Pending tip should not appear in public list");
+
+    cleanup_test_db(&pool).await;
+}
+
+/// Confirm path: after confirm_tip is called, tip appears in list.
+#[tokio::test]
+async fn test_confirmed_tip_appears_in_list() {
+    let pool = setup_test_db().await;
+    let (app, _) = create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    create_creator(&server, "confirm_creator").await;
+
+    // Submit tip
+    let resp = server.post("/tips").json(&tip_body("confirm_creator", TX_HASH)).await;
+    resp.assert_status(StatusCode::CREATED);
+    let body: Value = resp.json();
+    let tip_id: uuid::Uuid = body["id"].as_str().unwrap().parse().unwrap();
+
+    // Build a minimal AppState for calling confirm_tip directly
+    let state = {
+        let performance = Arc::new(stellar_tipjar_backend::db::performance::PerformanceMonitor::new());
+        let (queue, _) = stellar_tipjar_backend::queue::VerificationQueue::new();
+        let moderation = Arc::new(stellar_tipjar_backend::moderation::ModerationService::new(pool.clone()));
+        Arc::new(stellar_tipjar_backend::db::connection::AppState {
+            db: pool.clone(),
+            verifier: MockTipVerifier::always_confirm(),
+            queue,
+            performance,
+            moderation,
+            redis: None,
+            broadcast_tx: tokio::sync::broadcast::channel(16).0,
+            cache: None,
+            invalidator: None,
+            db_circuit_breaker: Arc::new(stellar_tipjar_backend::services::circuit_breaker::CircuitBreaker::new(5, std::time::Duration::from_secs(60))),
+            lock_service: None,
+        })
+    };
+
+    // Drive to confirmed
+    tip_controller::confirm_tip(&state, tip_id).await.expect("confirm_tip failed");
+
+    // Now the tip should appear in the list
+    let list_resp = server.get("/creators/confirm_creator/tips").await;
+    list_resp.assert_status(StatusCode::OK);
+    let tips: Vec<Value> = list_resp.json();
+    assert_eq!(tips.len(), 1);
+    assert_eq!(tips[0]["status"], "confirmed");
+
+    cleanup_test_db(&pool).await;
+}
+
+/// Rejected tips must not appear in the public list.
+#[tokio::test]
+async fn test_rejected_tip_hidden_from_list() {
+    let pool = setup_test_db().await;
+    let (app, _) = create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    create_creator(&server, "reject_creator").await;
+
+    let resp = server.post("/tips").json(&tip_body("reject_creator", TX_HASH)).await;
+    resp.assert_status(StatusCode::CREATED);
+    let tip_id: uuid::Uuid = resp.json::<Value>()["id"].as_str().unwrap().parse().unwrap();
+
+    let state = {
+        let performance = Arc::new(stellar_tipjar_backend::db::performance::PerformanceMonitor::new());
+        let (queue, _) = stellar_tipjar_backend::queue::VerificationQueue::new();
+        let moderation = Arc::new(stellar_tipjar_backend::moderation::ModerationService::new(pool.clone()));
+        Arc::new(stellar_tipjar_backend::db::connection::AppState {
+            db: pool.clone(),
+            verifier: MockTipVerifier::always_confirm(),
+            queue,
+            performance,
+            moderation,
+            redis: None,
+            broadcast_tx: tokio::sync::broadcast::channel(16).0,
+            cache: None,
+            invalidator: None,
+            db_circuit_breaker: Arc::new(stellar_tipjar_backend::services::circuit_breaker::CircuitBreaker::new(5, std::time::Duration::from_secs(60))),
+            lock_service: None,
+        })
+    };
+
+    tip_controller::reject_tip(&state, tip_id, "amount mismatch").await.expect("reject_tip failed");
+
+    let list_resp = server.get("/creators/reject_creator/tips").await;
+    list_resp.assert_status(StatusCode::OK);
+    let tips: Vec<Value> = list_resp.json();
+    assert!(tips.is_empty(), "Rejected tip must not appear in public list");
+
+    cleanup_test_db(&pool).await;
+}
+
+/// Amount mismatch: verifier returns Rejected – tip must not reach confirmed.
+#[tokio::test]
+async fn test_amount_mismatch_is_rejected() {
+    let pool = setup_test_db().await;
+    let verifier = MockTipVerifier::with_outcomes(vec![Ok(VerifyOutcome::Rejected {
+        reason: "Amount mismatch: expected 105000000 stroops, on-chain 100000000".to_string(),
+    })]);
+    let (app, _) = create_test_app_with_verifier(pool.clone(), verifier).await;
+    let server = TestServer::new(app).unwrap();
+
+    create_creator(&server, "amount_creator").await;
+
+    let resp = server.post("/tips").json(&tip_body("amount_creator", TX_HASH)).await;
+    // The tip is accepted into pending_verification (HTTP 201) – rejection happens asynchronously.
+    resp.assert_status(StatusCode::CREATED);
+    let body: Value = resp.json();
+    assert_eq!(body["status"], "pending_verification");
+
+    cleanup_test_db(&pool).await;
+}
+
+/// Destination mismatch: verifier rejects due to wrong destination.
+#[tokio::test]
+async fn test_destination_mismatch_rejected() {
+    let pool = setup_test_db().await;
+    let verifier = MockTipVerifier::with_outcomes(vec![Ok(VerifyOutcome::Rejected {
+        reason: "No native payment to GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 found in transaction".to_string(),
+    })]);
+    let (app, _) = create_test_app_with_verifier(pool.clone(), verifier).await;
+    let server = TestServer::new(app).unwrap();
+
+    create_creator(&server, "dest_creator").await;
+    let resp = server.post("/tips").json(&tip_body("dest_creator", TX_HASH)).await;
+    resp.assert_status(StatusCode::CREATED);
+    assert_eq!(resp.json::<Value>()["status"], "pending_verification");
+
+    cleanup_test_db(&pool).await;
+}
+
+/// Memo mismatch: verifier rejects due to wrong memo.
+#[tokio::test]
+async fn test_memo_mismatch_rejected() {
+    let pool = setup_test_db().await;
+    let verifier = MockTipVerifier::with_outcomes(vec![Ok(VerifyOutcome::Rejected {
+        reason: "Memo mismatch: expected 'expected_memo', got 'wrong_memo'".to_string(),
+    })]);
+    let (app, _) = create_test_app_with_verifier(pool.clone(), verifier).await;
+    let server = TestServer::new(app).unwrap();
+
+    create_creator(&server, "memo_creator").await;
+    let resp = server
+        .post("/tips")
         .json(&json!({
-            "username": "tiplist",
-            "wallet_address": "GJK012",
-            "email": "list@example.com"
+            "username": "memo_creator",
+            "amount": "10.5",
+            "transaction_hash": TX_HASH,
+            "tipper_source_account": TIPPER_ADDR,
+            "memo": "expected_memo"
         }))
         .await;
+    resp.assert_status(StatusCode::CREATED);
+    assert_eq!(resp.json::<Value>()["status"], "pending_verification");
 
-    // Manually insert some tips using SQL to avoid stellar verification during tests
-    sqlx::query(
-        "INSERT INTO tips (id, creator_username, amount, transaction_hash, created_at) VALUES ($1, $2, $3, $4, NOW())"
+    cleanup_test_db(&pool).await;
+}
+
+/// Duplicate tx_hash race: two concurrent submissions of the same hash must
+/// result in exactly one tip record and one 409 Conflict response.
+#[tokio::test]
+async fn test_duplicate_tx_hash_race() {
+    let pool = setup_test_db().await;
+
+    // Pre-create the creator outside the race so the FK constraint is satisfied.
+    {
+        let (app, _) = create_test_app(pool.clone()).await;
+        let server = TestServer::new(app).unwrap();
+        create_creator(&server, "race_creator").await;
+    }
+
+    // Fire 5 concurrent submissions of the same tx_hash.
+    let mut join_set = JoinSet::new();
+    for _ in 0..5 {
+        let pool_clone = pool.clone();
+        join_set.spawn(async move {
+            let (app, _) = create_test_app(pool_clone).await;
+            let server = TestServer::new(app).unwrap();
+            let resp = server.post("/tips").json(&tip_body("race_creator", TX_HASH)).await;
+            resp.status_code()
+        });
+    }
+
+    let mut created = 0u32;
+    let mut conflict = 0u32;
+    while let Some(res) = join_set.join_next().await {
+        match res.unwrap() {
+            StatusCode::CREATED => created += 1,
+            StatusCode::CONFLICT => conflict += 1,
+            other => panic!("Unexpected status code: {}", other),
+        }
+    }
+
+    assert_eq!(created, 1, "Exactly one submission should succeed");
+    assert_eq!(conflict, 4, "The other four should be rejected as duplicates");
+
+    // Verify only one record in the database
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tips WHERE transaction_hash = $1")
+        .bind(TX_HASH)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "Database must contain exactly one tip for this tx_hash");
+
+    cleanup_test_db(&pool).await;
+}
+
+/// Horizon 5xx retry: the verifier returns a network error on the first call,
+/// then confirms on the second (simulating a brief Horizon outage).
+/// The worker re-enqueues and the tip eventually reaches confirmed.
+#[tokio::test]
+async fn test_horizon_5xx_retry_eventual_confirm() {
+    use stellar_tipjar_backend::errors::StellarError;
+    use tokio::time::{sleep, Duration};
+
+    let pool = setup_test_db().await;
+
+    // Sequence: NetworkUnavailable → Confirmed
+    let verifier = MockTipVerifier::with_outcomes(vec![
+        Err(AppError::Stellar(StellarError::NetworkUnavailable)),
+        Ok(VerifyOutcome::Confirmed),
+    ]);
+
+    let performance = Arc::new(stellar_tipjar_backend::db::performance::PerformanceMonitor::new());
+    let (queue, queue_rx) = stellar_tipjar_backend::queue::VerificationQueue::new();
+    let moderation = Arc::new(stellar_tipjar_backend::moderation::ModerationService::new(pool.clone()));
+
+    let state = Arc::new(stellar_tipjar_backend::db::connection::AppState {
+        db: pool.clone(),
+        verifier,
+        queue,
+        performance,
+        moderation,
+        redis: None,
+        broadcast_tx: tokio::sync::broadcast::channel(16).0,
+        cache: None,
+        invalidator: None,
+        db_circuit_breaker: Arc::new(stellar_tipjar_backend::services::circuit_breaker::CircuitBreaker::new(5, std::time::Duration::from_secs(60))),
+        lock_service: None,
+    });
+
+    // Spawn the real queue worker so jobs are processed
+    stellar_tipjar_backend::queue::worker::spawn_worker(Arc::clone(&state), queue_rx);
+
+    // Create creator
+    sqlx::query("INSERT INTO creators (id, username, wallet_address, email, created_at) VALUES (gen_random_uuid(), $1, $2, $3, NOW()) ON CONFLICT DO NOTHING")
+        .bind("retry_creator")
+        .bind(CREATOR_WALLET)
+        .bind("retry@test.com")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Submit tip
+    let tip = tip_controller::record_tip(
+        &state,
+        stellar_tipjar_backend::models::tip::RecordTipRequest {
+            username: "retry_creator".to_string(),
+            amount: "10.5".to_string(),
+            transaction_hash: TX_HASH.to_string(),
+            tipper_source_account: TIPPER_ADDR.to_string(),
+            memo: None,
+        },
     )
-    .bind(uuid::Uuid::new_v4())
-    .bind("tiplist")
-    .bind("5.5")
-    .bind("HASH1")
+    .await
+    .expect("record_tip failed");
+
+    assert_eq!(
+        tip.effective_status(),
+        stellar_tipjar_backend::models::tip::TipStatus::PendingVerification
+    );
+
+    // Give the worker time to process (first attempt fails + backoff + retry)
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        sleep(Duration::from_millis(200)).await;
+        let status: Option<String> =
+            sqlx::query_scalar("SELECT status FROM tips WHERE id = $1")
+                .bind(tip.id)
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+
+        if status.as_deref() == Some("confirmed") {
+            break; // ✅
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("Tip was not confirmed within the deadline. Status: {:?}", status);
+        }
+    }
+
+    cleanup_test_db(&pool).await;
+}
+
+/// Reconciliation of stuck tips: insert a pending tip with a created_at in the
+/// past, run `reconciliation::run_once`, and confirm the tip is re-enqueued.
+#[tokio::test]
+async fn test_reconciliation_re_enqueues_stuck_tips() {
+    let pool = setup_test_db().await;
+
+    let performance = Arc::new(stellar_tipjar_backend::db::performance::PerformanceMonitor::new());
+    let (queue, _queue_rx) = stellar_tipjar_backend::queue::VerificationQueue::new();
+    let moderation = Arc::new(stellar_tipjar_backend::moderation::ModerationService::new(pool.clone()));
+
+    let state = Arc::new(stellar_tipjar_backend::db::connection::AppState {
+        db: pool.clone(),
+        verifier: MockTipVerifier::always_confirm(),
+        queue,
+        performance,
+        moderation,
+        redis: None,
+        broadcast_tx: tokio::sync::broadcast::channel(16).0,
+        cache: None,
+        invalidator: None,
+        db_circuit_breaker: Arc::new(stellar_tipjar_backend::services::circuit_breaker::CircuitBreaker::new(5, std::time::Duration::from_secs(60))),
+        lock_service: None,
+    });
+
+    // Create creator
+    sqlx::query("INSERT INTO creators (id, username, wallet_address, email, created_at) VALUES (gen_random_uuid(), $1, $2, $3, NOW()) ON CONFLICT DO NOTHING")
+        .bind("recon_creator")
+        .bind(CREATOR_WALLET)
+        .bind("recon@test.com")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Insert a stuck pending tip (created 10 minutes ago)
+    sqlx::query(
+        r#"
+        INSERT INTO tips (id, creator_username, amount, transaction_hash, tipper_source_account, status, created_at)
+        VALUES (gen_random_uuid(), $1, '5.0', $2, $3, 'pending_verification', NOW() - INTERVAL '10 minutes')
+        "#,
+    )
+    .bind("recon_creator")
+    .bind(TX_HASH2)
+    .bind(TIPPER_ADDR)
     .execute(&pool)
     .await
     .unwrap();
 
-    let response = server.get("/creators/tiplist/tips").await;
-    response.assert_status(StatusCode::OK);
+    // Run reconciliation
+    let enqueued = stellar_tipjar_backend::jobs::reconciliation::run_once(Arc::clone(&state)).await;
+    assert_eq!(enqueued, 1, "Reconciliation should have re-enqueued 1 stuck tip");
 
-    let body = response.json::<serde_json::Value>();
-    assert_eq!(body["data"][0]["amount"], "5.5");
+    cleanup_test_db(&pool).await;
+}
 
-    common::cleanup_test_db(&pool).await;
+/// Validation: request body with no tipper_source_account must be rejected.
+#[tokio::test]
+async fn test_invalid_request_missing_source_account() {
+    let pool = setup_test_db().await;
+    let (app, _) = create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    create_creator(&server, "valid_creator2").await;
+
+    let resp = server
+        .post("/tips")
+        .json(&json!({
+            "username": "valid_creator2",
+            "amount": "10.5",
+            "transaction_hash": TX_HASH,
+            // Missing tipper_source_account
+        }))
+        .await;
+
+    // Deserialization failure → 400 Bad Request
+    assert_eq!(resp.status_code(), StatusCode::BAD_REQUEST);
+
+    cleanup_test_db(&pool).await;
+}
+
+/// Amount validation: amounts with more than 7 decimal places must be rejected.
+#[tokio::test]
+async fn test_invalid_amount_too_many_decimals() {
+    let pool = setup_test_db().await;
+    let (app, _) = create_test_app(pool.clone()).await;
+    let server = TestServer::new(app).unwrap();
+
+    create_creator(&server, "decimal_creator").await;
+
+    let resp = server
+        .post("/tips")
+        .json(&json!({
+            "username": "decimal_creator",
+            "amount": "1.12345678",
+            "transaction_hash": TX_HASH,
+            "tipper_source_account": TIPPER_ADDR
+        }))
+        .await;
+
+    assert_eq!(resp.status_code(), StatusCode::BAD_REQUEST);
+
+    cleanup_test_db(&pool).await;
 }
 
 #[tokio::test]
@@ -115,8 +489,8 @@ async fn test_get_creator_tips_paginated() {
 
     for i in 1..=5i32 {
         sqlx::query(
-            "INSERT INTO tips (id, creator_username, amount, transaction_hash, created_at) \
-             VALUES ($1, $2, $3, $4, NOW())",
+            "INSERT INTO tips (id, creator_username, amount, transaction_hash, status, created_at) \
+             VALUES ($1, $2, $3, $4, 'confirmed', NOW())",
         )
         .bind(Uuid::new_v4())
         .bind("paguser")
@@ -153,92 +527,6 @@ async fn test_get_creator_tips_paginated() {
 }
 
 #[tokio::test]
-async fn test_matching_campaign_applies_funds_and_creates_notification() {
-    let pool = common::setup_test_db().await;
-    let mock_server = MockServer::start();
-    let (app, _) = common::create_test_app_with_mock_stellar(
-        pool.clone(),
-        &mock_server.url(""),
-    )
-    .await;
-    let server = TestServer::new(app).unwrap();
-
-    mock_server.mock(|when, then| {
-        when.method(GET).path_contains("/transactions/TXMATCH1");
-        then.status(200).json_body(json!({
-            "id": "TXMATCH1",
-            "hash": "TXMATCH1",
-            "successful": true
-        }));
-    });
-
-    server
-        .post("/creators")
-        .json(&json!({
-            "username": "matchcreator",
-            "wallet_address": "GMATCH001",
-            "email": "match@example.com"
-        }))
-        .await;
-
-    let campaign_id = Uuid::new_v4();
-    sqlx::query(
-        "INSERT INTO campaigns (id, sponsor_name, creator_username, match_ratio, per_tip_cap, total_budget, remaining_budget, active, starts_at, ends_at) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE, NOW() - INTERVAL '1 day', NOW() + INTERVAL '1 day')",
-    )
-    .bind(campaign_id)
-    .bind("SponsorCo")
-    .bind("matchcreator")
-    .bind("1.0")
-    .bind("10.0")
-    .bind("10.0")
-    .bind("10.0")
-    .execute(&pool)
-    .await
-    .unwrap();
-
-    let response = server
-        .post("/tips")
-        .json(&json!({
-            "username": "matchcreator",
-            "amount": "5.0",
-            "transaction_hash": "TXMATCH1"
-        }))
-        .await;
-
-    response.assert_status(StatusCode::CREATED);
-
-    let matched_amount: String = sqlx::query_scalar(
-        "SELECT matched_amount FROM campaign_matches WHERE tip_id = (SELECT id FROM tips WHERE transaction_hash = $1)"
-    )
-    .bind("TXMATCH1")
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert_eq!(matched_amount, "5.0");
-
-    let remaining_budget: String = sqlx::query_scalar(
-        "SELECT remaining_budget FROM campaigns WHERE id = $1"
-    )
-    .bind(campaign_id)
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert_eq!(remaining_budget, "5.0");
-
-    let notification_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM notifications WHERE creator_username = $1 AND \"type\" = 'campaign_matched'"
-    )
-    .bind("matchcreator")
-    .fetch_one(&pool)
-    .await
-    .unwrap();
-    assert_eq!(notification_count, 1);
-
-    common::cleanup_test_db(&pool).await;
-}
-
-#[tokio::test]
 async fn test_list_tips_with_filters() {
     let pool = common::setup_test_db().await;
     let (app, _) = common::create_test_app(pool.clone()).await;
@@ -251,8 +539,8 @@ async fn test_list_tips_with_filters() {
 
     for (amount, hash) in [("5.0", "FHASH1"), ("15.0", "FHASH2"), ("25.0", "FHASH3")] {
         sqlx::query(
-            "INSERT INTO tips (id, creator_username, amount, transaction_hash, created_at) \
-             VALUES ($1, $2, $3, $4, NOW())",
+            "INSERT INTO tips (id, creator_username, amount, transaction_hash, status, created_at) \
+             VALUES ($1, $2, $3, $4, 'confirmed', NOW())",
         )
         .bind(uuid::Uuid::new_v4())
         .bind("filtuser")
@@ -287,4 +575,33 @@ async fn test_list_tips_with_filters() {
     assert_eq!(body["limit"], 100);
 
     common::cleanup_test_db(&pool).await;
+}
+
+// ─────────────────────────── Unit tests ─────────────────────────────────────
+
+#[cfg(test)]
+mod unit {
+    use stellar_tipjar_backend::validation::amount::xlm_to_stroops_str;
+    use stellar_tipjar_backend::services::stellar_service::StellarService;
+
+    /// Integer stroop conversion must be exact.
+    #[test]
+    fn stroop_conversion_exact() {
+        assert_eq!(xlm_to_stroops_str("10.5").unwrap(), 105_000_000);
+        assert_eq!(xlm_to_stroops_str("1.0000000").unwrap(), 10_000_000);
+        assert_eq!(xlm_to_stroops_str("0.0000001").unwrap(), 1);
+        assert_eq!(xlm_to_stroops_str("100").unwrap(), 1_000_000_000);
+    }
+
+    #[test]
+    fn stroop_conversion_rejects_too_many_decimals() {
+        assert!(xlm_to_stroops_str("1.12345678").is_err());
+    }
+
+    /// StellarService::xlm_to_stroops must match our helper.
+    #[test]
+    fn stellar_service_xlm_to_stroops() {
+        assert_eq!(StellarService::xlm_to_stroops("10.5000000").unwrap(), 105_000_000);
+        assert_eq!(StellarService::xlm_to_stroops("0.0000001").unwrap(), 1);
+    }
 }


### PR DESCRIPTION
- Add migration 0012: status column (pending_verification/confirmed/rejected), tipper_source_account, UNIQUE constraint on tx_hash, CHECK constraint, status/created_at indexes, backfill existing rows as confirmed

- TipVerifier trait (src/services/stellar_service.rs) with TipVerifyRequest and VerifyOutcome; StellarService implements full on-chain verification: amount in stroops (integer, no float), destination, source_account, memo, HorizonOperations check; xlm_to_stroops helper with no floating point

- Two-phase tip state: record_tip inserts as pending_verification with ON CONFLICT DO NOTHING (exactly-once ingestion); confirm_tip/reject_tip transition state and gate all webhooks/analytics on confirmed only

- VerificationQueue (src/queue/) with bounded mpsc channel; worker consumes jobs with exponential backoff retry up to 5 attempts; reconciliation job (src/jobs/) re-drives stuck pending tips every 60 seconds

- AppState: replaced stellar: StellarService with verifier: Arc<dyn TipVerifier>
  and queue: VerificationQueue for testability and dependency injection

- Tests: happy path, amount/destination/memo mismatch, duplicate tx_hash race (5 concurrent → exactly 1 created + 4 conflict), Horizon 5xx retry with eventual confirm, reconciliation of stuck tips, input validation; MockTipVerifier with programmable outcome sequences (never an env flag)

- Fixed merge-conflict artifacts in routes/creators.rs, creator_controller.rs, export_controller.rs; all tip list/export queries gated on status=confirmed

Closes #341